### PR TITLE
fix: suppress slide arrow nav inside editor controls

### DIFF
--- a/src/editor/js/editor-init.js
+++ b/src/editor/js/editor-init.js
@@ -149,6 +149,13 @@ popoverBgColorInput.addEventListener('input', () => {
   }, 'Background color updated.', { delay: 300 });
 });
 
+function hasEditableFocus() {
+  const activeElement = document.activeElement;
+  if (!(activeElement instanceof HTMLElement)) return false;
+  if (activeElement.matches('input, textarea, select')) return true;
+  return activeElement.isContentEditable;
+}
+
 // Style toggles
 toggleBold.addEventListener('click', () => {
   mutateSelectedObject((el) => {
@@ -199,9 +206,9 @@ alignRight.addEventListener('click', () => {
 
 // Global keyboard
 document.addEventListener('keydown', (event) => {
-  const inPromptField = document.activeElement === promptInput;
+  const inEditableField = hasEditableFocus();
 
-  if (state.toolMode === TOOL_MODE_SELECT && (event.ctrlKey || event.metaKey) && !inPromptField) {
+  if (state.toolMode === TOOL_MODE_SELECT && (event.ctrlKey || event.metaKey) && !inEditableField) {
     const key = event.key.toLowerCase();
     if (key === 'b') { event.preventDefault(); if (!toggleBold.disabled) toggleBold.click(); return; }
     if (key === 'i') { event.preventDefault(); if (!toggleItalic.disabled) toggleItalic.click(); return; }
@@ -219,7 +226,7 @@ document.addEventListener('keydown', (event) => {
     return;
   }
 
-  if (inPromptField) return;
+  if (inEditableField) return;
 
   if (event.key === 'ArrowLeft') {
     event.preventDefault();

--- a/tests/editor/editor-ui.e2e.test.js
+++ b/tests/editor/editor-ui.e2e.test.js
@@ -454,6 +454,105 @@ test('supports direct object selection through the persistent inspector and swit
   }
 });
 
+test('suppresses slide arrow navigation while focus is inside editor form controls', { concurrency: false }, async () => {
+  const workspace = await mkdtemp(join(os.tmpdir(), 'editor-ui-keyboard-nav-e2e-'));
+  await writeSlides(workspace);
+
+  const port = 3655;
+  const serverOutput = { value: '' };
+  const serverScriptPath = join(REPO_ROOT, 'scripts', 'editor-server.js');
+  const server = spawn(process.execPath, [serverScriptPath, '--port', String(port)], {
+    cwd: workspace,
+    env: {
+      ...process.env,
+      PPT_AGENT_PACKAGE_ROOT: REPO_ROOT,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  server.stdout.on('data', (chunk) => {
+    serverOutput.value += chunk.toString();
+  });
+  server.stderr.on('data', (chunk) => {
+    serverOutput.value += chunk.toString();
+  });
+
+  let browser;
+  try {
+    await waitForServerReady(port, server, serverOutput);
+
+    browser = await chromium.launch({ headless: true });
+    const page = await browser.newPage({ viewport: { width: 1600, height: 1000 } });
+    await page.goto(`http://localhost:${port}/`, { waitUntil: 'domcontentloaded' });
+
+    await page.waitForSelector('#draw-layer');
+    await page.waitForSelector('#slide-counter');
+    await page.waitForTimeout(800);
+
+    await page.focus('#model-select');
+    await page.keyboard.press('ArrowRight');
+    await page.waitForTimeout(150);
+    await page.waitForFunction(() => {
+      const counter = document.querySelector('#slide-counter');
+      return counter && /1\s*\/\s*2/.test(counter.textContent || '');
+    });
+
+    await page.click('#tool-mode-select');
+
+    const drawLayer = await page.locator('#draw-layer').boundingBox();
+    assert.ok(drawLayer, 'draw layer not found');
+    await page.mouse.click(
+      drawLayer.x + drawLayer.width * 0.22,
+      drawLayer.y + drawLayer.height * 0.18,
+    );
+
+    await page.waitForFunction(() => {
+      const textInput = document.querySelector('#popover-text-input');
+      const sizeInput = document.querySelector('#popover-size-input');
+      return textInput && sizeInput && !textInput.disabled && !sizeInput.disabled;
+    });
+
+    await page.focus('#popover-text-input');
+    await page.keyboard.press('ArrowRight');
+    await page.waitForTimeout(150);
+    await page.waitForFunction(() => {
+      const counter = document.querySelector('#slide-counter');
+      return counter && /1\s*\/\s*2/.test(counter.textContent || '');
+    });
+
+    await page.focus('#popover-size-input');
+    await page.keyboard.press('ArrowLeft');
+    await page.waitForTimeout(150);
+    await page.waitForFunction(() => {
+      const counter = document.querySelector('#slide-counter');
+      return counter && /1\s*\/\s*2/.test(counter.textContent || '');
+    });
+
+    await page.mouse.click(
+      drawLayer.x + drawLayer.width * 0.75,
+      drawLayer.y + drawLayer.height * 0.75,
+    );
+    await page.keyboard.press('ArrowRight');
+    await page.waitForFunction(() => {
+      const counter = document.querySelector('#slide-counter');
+      return counter && /2\s*\/\s*2/.test(counter.textContent || '');
+    });
+
+    await page.keyboard.press('ArrowLeft');
+    await page.waitForFunction(() => {
+      const counter = document.querySelector('#slide-counter');
+      return counter && /1\s*\/\s*2/.test(counter.textContent || '');
+    });
+  } finally {
+    if (browser) {
+      await browser.close().catch(() => {});
+    }
+    server.kill('SIGTERM');
+    await sleep(400);
+    await rm(workspace, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
 test('keeps the persistent inspector beside the slide in a 16:9 viewport', { concurrency: false }, async () => {
   const workspace = await mkdtemp(join(os.tmpdir(), 'editor-ui-toolbox-layout-e2e-'));
   await writeSlides(workspace);


### PR DESCRIPTION
## Summary
- broaden the editor keyboard focus guard so slide navigation is skipped while focus is inside input, textarea, select, or contenteditable controls
- add E2E regression coverage for `#model-select`, `#popover-text-input`, and `#popover-size-input`
- preserve ArrowLeft/ArrowRight slide navigation when focus returns to the slide canvas

## Testing
- `node --test tests/editor/editor-ui.e2e.test.js`

AI disclosure: This PR was prepared by GithubClaw Coder, an AI coding agent.