### PR TITLE
feat: modularize slide validator for auto-fix groundwork

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "validate": "node scripts/validate-slides.js",
     "convert": "node convert.cjs",
     "codex:install-skills": "node scripts/install-codex-skills.js --force",
-    "test": "node --test tests/editor/editor-codex-edit.test.js tests/pdf/html2pdf.test.js tests/pdf/html2pdf.e2e.test.js tests/figma/figma-export.test.js tests/validation/validate-slides.test.js",
+    "test": "node --test tests/editor/editor-codex-edit.test.js tests/pdf/html2pdf.test.js tests/pdf/html2pdf.e2e.test.js tests/figma/figma-export.test.js tests/validation/validate-slides.test.js tests/validator/validate-slides.test.js",
     "test:e2e": "node --test tests/editor/editor-ui.e2e.test.js tests/editor/editor-concurrency.e2e.test.js"
   },
   "dependencies": {

--- a/scripts/validate-slides.js
+++ b/scripts/validate-slides.js
@@ -1,42 +1,35 @@
 #!/usr/bin/env node
 
 import { resolve } from 'node:path';
-import { chromium } from 'playwright';
-import { DEFAULT_SLIDES_DIR, getValidateUsage, parseValidateCliArgs } from '../src/validation/cli.js';
-import { createValidationFailure, createValidationResult, findSlideFiles, scanSlides } from '../src/validation/core.js';
+import { pathToFileURL } from 'node:url';
+
+import {
+  buildValidationFailure,
+  parseCliArgs,
+  printUsage,
+  validateSlides,
+} from '../src/validator/index.js';
 
 async function main() {
-  const options = parseValidateCliArgs(process.argv.slice(2));
+  const options = parseCliArgs(process.argv.slice(2));
   if (options.help) {
-    process.stdout.write(`${getValidateUsage()}\n`);
+    printUsage();
     return;
   }
 
   const slidesDir = resolve(process.cwd(), options.slidesDir);
-  const slideFiles = await findSlideFiles(slidesDir);
-  if (slideFiles.length === 0) {
-    throw new Error(`No slide-*.html files found in: ${slidesDir}`);
-  }
+  const result = await validateSlides(slidesDir);
 
-  const browser = await chromium.launch({ headless: true });
-  const context = await browser.newContext({ viewport: { width: 1920, height: 1080 } });
-  const page = await context.newPage();
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
 
-  try {
-    const slides = await scanSlides(page, slidesDir, slideFiles);
-    const result = createValidationResult(slides);
-    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
-
-    if (result.summary.failedSlides > 0) {
-      process.exitCode = 1;
-    }
-  } finally {
-    await browser.close();
+  if (result.summary.failedSlides > 0) {
+    process.exitCode = 1;
   }
 }
 
-main().catch((error) => {
-  const failure = createValidationFailure(error);
-  process.stdout.write(`${JSON.stringify(failure, null, 2)}\n`);
-  process.exit(1);
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    process.stdout.write(`${JSON.stringify(buildValidationFailure(error), null, 2)}\n`);
+    process.exit(1);
+  });
+}

--- a/src/validator/cli.js
+++ b/src/validator/cli.js
@@ -1,0 +1,58 @@
+import { DEFAULT_SLIDES_DIR } from './constants.js';
+
+export function printUsage() {
+  process.stdout.write(
+    [
+      'Usage: node scripts/validate-slides.js [options]',
+      '',
+      'Options:',
+      `  --slides-dir <path>  Slide directory (default: ${DEFAULT_SLIDES_DIR})`,
+      '  -h, --help           Show this help message',
+    ].join('\n'),
+  );
+  process.stdout.write('\n');
+}
+
+function readOptionValue(args, index, optionName) {
+  const next = args[index + 1];
+  if (!next || next.startsWith('-')) {
+    throw new Error(`Missing value for ${optionName}.`);
+  }
+  return next;
+}
+
+export function parseCliArgs(args) {
+  const options = {
+    slidesDir: DEFAULT_SLIDES_DIR,
+    help: false,
+  };
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+
+    if (arg === '-h' || arg === '--help') {
+      options.help = true;
+      continue;
+    }
+
+    if (arg === '--slides-dir') {
+      options.slidesDir = readOptionValue(args, i, '--slides-dir');
+      i += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--slides-dir=')) {
+      options.slidesDir = arg.slice('--slides-dir='.length);
+      continue;
+    }
+
+    throw new Error(`Unknown option: ${arg}`);
+  }
+
+  if (typeof options.slidesDir !== 'string' || options.slidesDir.trim() === '') {
+    throw new Error('--slides-dir must be a non-empty string.');
+  }
+
+  options.slidesDir = options.slidesDir.trim();
+  return options;
+}

--- a/src/validator/constants.js
+++ b/src/validator/constants.js
@@ -1,0 +1,10 @@
+export const FRAME_PT = { width: 720, height: 405 };
+export const PT_TO_PX = 96 / 72;
+export const FRAME_PX = {
+  width: FRAME_PT.width * PT_TO_PX,
+  height: FRAME_PT.height * PT_TO_PX,
+};
+export const SLIDE_FILE_PATTERN = /^slide-.*\.html$/i;
+export const TEXT_SELECTOR = 'p,h1,h2,h3,h4,h5,h6,li';
+export const TOLERANCE_PX = 0.5;
+export const DEFAULT_SLIDES_DIR = 'slides';

--- a/src/validator/index.js
+++ b/src/validator/index.js
@@ -1,0 +1,20 @@
+export {
+  DEFAULT_SLIDES_DIR,
+  FRAME_PT,
+  FRAME_PX,
+  PT_TO_PX,
+  SLIDE_FILE_PATTERN,
+  TEXT_SELECTOR,
+  TOLERANCE_PX,
+} from './constants.js';
+export { parseCliArgs, printUsage } from './cli.js';
+export { inspectSlide, inspectSlideDocument } from './inspect.js';
+export {
+  buildIssue,
+  summarizeSlides,
+  buildValidationFailure,
+  buildValidationResult,
+  validateSlides,
+  validateSlidesInPage,
+} from './report.js';
+export { findSlideFiles, sortSlideFiles } from './slide-files.js';

--- a/src/validator/inspect.js
+++ b/src/validator/inspect.js
@@ -1,0 +1,207 @@
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { FRAME_PX, TEXT_SELECTOR, TOLERANCE_PX } from './constants.js';
+
+export function inspectSlideDocument({ framePx, textSelector, tolerancePx }) {
+  const skipTags = new Set(['SCRIPT', 'STYLE', 'META', 'LINK', 'HEAD', 'TITLE', 'NOSCRIPT']);
+  const critical = [];
+  const warning = [];
+  const seenOverlaps = new Set();
+
+  const round = (value) => Number(value.toFixed(2));
+
+  const normalizeRect = (rect) => {
+    const left = rect.left ?? rect.x ?? 0;
+    const top = rect.top ?? rect.y ?? 0;
+    const width = rect.width ?? (rect.right - left) ?? 0;
+    const height = rect.height ?? (rect.bottom - top) ?? 0;
+    const right = rect.right ?? (left + width);
+    const bottom = rect.bottom ?? (top + height);
+    return {
+      x: round(left),
+      y: round(top),
+      width: round(width),
+      height: round(height),
+      left: round(left),
+      top: round(top),
+      right: round(right),
+      bottom: round(bottom),
+    };
+  };
+
+  const elementPath = (element) => {
+    if (!element || element.nodeType !== Node.ELEMENT_NODE) return '';
+    if (element === document.body) return 'body';
+
+    const parts = [];
+    let current = element;
+
+    while (current && current.nodeType === Node.ELEMENT_NODE && current !== document.body) {
+      let part = current.tagName.toLowerCase();
+      if (current.id) {
+        part += `#${current.id}`;
+        parts.unshift(part);
+        break;
+      }
+
+      const classNames = Array.from(current.classList).slice(0, 2);
+      if (classNames.length > 0) {
+        part += `.${classNames.join('.')}`;
+      }
+
+      if (current.parentElement) {
+        const siblingsOfSameTag = Array.from(current.parentElement.children)
+          .filter((sibling) => sibling.tagName === current.tagName);
+        if (siblingsOfSameTag.length > 1) {
+          const index = siblingsOfSameTag.indexOf(current);
+          part += `:nth-of-type(${index + 1})`;
+        }
+      }
+
+      parts.unshift(part);
+      current = current.parentElement;
+    }
+
+    return `body > ${parts.join(' > ')}`;
+  };
+
+  const isVisible = (element) => {
+    if (skipTags.has(element.tagName)) return false;
+    const style = window.getComputedStyle(element);
+    if (style.display === 'none' || style.visibility === 'hidden' || Number(style.opacity) === 0) {
+      return false;
+    }
+    const rect = element.getBoundingClientRect();
+    return rect.width > 0 && rect.height > 0;
+  };
+
+  const bodyRect = document.body.getBoundingClientRect();
+  const frameRect = {
+    left: bodyRect.left,
+    top: bodyRect.top,
+    right: bodyRect.left + (bodyRect.width || framePx.width),
+    bottom: bodyRect.top + (bodyRect.height || framePx.height),
+    width: bodyRect.width || framePx.width,
+    height: bodyRect.height || framePx.height,
+  };
+
+  const allVisibleElements = Array.from(document.body.querySelectorAll('*')).filter(isVisible);
+  const visibleSet = new Set(allVisibleElements);
+
+  for (const element of allVisibleElements) {
+    const rect = element.getBoundingClientRect();
+    const outsideFrame = (
+      rect.left < frameRect.left - tolerancePx ||
+      rect.top < frameRect.top - tolerancePx ||
+      rect.right > frameRect.right + tolerancePx ||
+      rect.bottom > frameRect.bottom + tolerancePx
+    );
+
+    if (outsideFrame) {
+      critical.push({
+        code: 'overflow-outside-frame',
+        message: 'Element exceeds the 720pt x 405pt slide frame.',
+        element: elementPath(element),
+        bbox: normalizeRect(rect),
+        frame: normalizeRect(frameRect),
+      });
+    }
+  }
+
+  const textElements = Array.from(document.querySelectorAll(textSelector));
+  for (const element of textElements) {
+    if (!isVisible(element)) continue;
+    const content = (element.textContent || '').trim();
+    if (!content) continue;
+
+    const clipped = element.scrollHeight > element.clientHeight;
+    if (!clipped) continue;
+
+    critical.push({
+      code: 'text-clipped',
+      message: 'Text element is clipped because scrollHeight is larger than clientHeight.',
+      element: elementPath(element),
+      metrics: {
+        scrollHeight: element.scrollHeight,
+        clientHeight: element.clientHeight,
+      },
+      bbox: normalizeRect(element.getBoundingClientRect()),
+    });
+  }
+
+  const parents = [document.body, ...allVisibleElements];
+  for (const parent of parents) {
+    const children = Array.from(parent.children).filter((child) => visibleSet.has(child));
+    if (children.length < 2) continue;
+
+    for (let i = 0; i < children.length; i += 1) {
+      for (let j = i + 1; j < children.length; j += 1) {
+        const first = children[i];
+        const second = children[j];
+
+        const rectA = first.getBoundingClientRect();
+        const rectB = second.getBoundingClientRect();
+
+        const overlapWidth = Math.min(rectA.right, rectB.right) - Math.max(rectA.left, rectB.left);
+        const overlapHeight = Math.min(rectA.bottom, rectB.bottom) - Math.max(rectA.top, rectB.top);
+
+        if (overlapWidth <= tolerancePx || overlapHeight <= tolerancePx) continue;
+
+        const firstPath = elementPath(first);
+        const secondPath = elementPath(second);
+        const overlapKey = [firstPath, secondPath].sort().join('::');
+
+        if (seenOverlaps.has(overlapKey)) continue;
+        seenOverlaps.add(overlapKey);
+
+        warning.push({
+          code: 'sibling-overlap',
+          message: 'Sibling elements overlap in their bounding boxes.',
+          parent: elementPath(parent),
+          elements: [firstPath, secondPath],
+          intersection: {
+            x: round(Math.max(rectA.left, rectB.left)),
+            y: round(Math.max(rectA.top, rectB.top)),
+            width: round(overlapWidth),
+            height: round(overlapHeight),
+          },
+          boxes: [normalizeRect(rectA), normalizeRect(rectB)],
+        });
+      }
+    }
+  }
+
+  return { critical, warning };
+}
+
+export async function inspectSlide(page, fileName, slidesDir) {
+  const slidePath = join(slidesDir, fileName);
+  const slideUrl = pathToFileURL(slidePath).href;
+
+  await page.goto(slideUrl, { waitUntil: 'load' });
+  await page.evaluate(async () => {
+    if (document.fonts?.ready) {
+      await document.fonts.ready;
+    }
+  });
+
+  const inspection = await page.evaluate(inspectSlideDocument, {
+    framePx: FRAME_PX,
+    textSelector: TEXT_SELECTOR,
+    tolerancePx: TOLERANCE_PX,
+  });
+
+  const summary = {
+    criticalCount: inspection.critical.length,
+    warningCount: inspection.warning.length,
+  };
+
+  return {
+    slide: fileName,
+    status: summary.criticalCount > 0 ? 'fail' : 'pass',
+    critical: inspection.critical,
+    warning: inspection.warning,
+    summary,
+  };
+}

--- a/src/validator/report.js
+++ b/src/validator/report.js
@@ -1,0 +1,112 @@
+import { chromium } from 'playwright';
+
+import { FRAME_PT, FRAME_PX } from './constants.js';
+import { inspectSlide } from './inspect.js';
+import { findSlideFiles } from './slide-files.js';
+
+export function buildIssue(code, message, payload = {}) {
+  return { code, message, ...payload };
+}
+
+export function summarizeSlides(slides) {
+  const summary = {
+    totalSlides: slides.length,
+    passedSlides: 0,
+    failedSlides: 0,
+    criticalIssues: 0,
+    warnings: 0,
+  };
+
+  for (const slide of slides) {
+    if (slide.status === 'pass') {
+      summary.passedSlides += 1;
+    } else {
+      summary.failedSlides += 1;
+    }
+    summary.criticalIssues += slide.summary.criticalCount;
+    summary.warnings += slide.summary.warningCount;
+  }
+
+  return summary;
+}
+
+export function buildValidationResult(slides, generatedAt = new Date().toISOString()) {
+  return {
+    generatedAt,
+    frame: {
+      widthPt: FRAME_PT.width,
+      heightPt: FRAME_PT.height,
+      widthPx: FRAME_PX.width,
+      heightPx: FRAME_PX.height,
+    },
+    slides,
+    summary: summarizeSlides(slides),
+  };
+}
+
+export function buildValidationFailure(error, generatedAt = new Date().toISOString()) {
+  return {
+    generatedAt,
+    frame: {
+      widthPt: FRAME_PT.width,
+      heightPt: FRAME_PT.height,
+      widthPx: FRAME_PX.width,
+      heightPx: FRAME_PX.height,
+    },
+    slides: [],
+    summary: {
+      totalSlides: 0,
+      passedSlides: 0,
+      failedSlides: 0,
+      criticalIssues: 1,
+      warnings: 0,
+    },
+    error: error instanceof Error ? error.message : String(error),
+  };
+}
+
+export async function validateSlidesInPage(page, slidesDir) {
+  const slideFiles = await findSlideFiles(slidesDir);
+  if (slideFiles.length === 0) {
+    throw new Error(`No slide-*.html files found in: ${slidesDir}`);
+  }
+
+  const slides = [];
+  for (const slideFile of slideFiles) {
+    try {
+      const result = await inspectSlide(page, slideFile, slidesDir);
+      slides.push(result);
+    } catch (error) {
+      slides.push({
+        slide: slideFile,
+        status: 'fail',
+        critical: [
+          buildIssue(
+            'slide-validation-error',
+            'Slide validation failed before checks could complete.',
+            { detail: error instanceof Error ? error.message : String(error) },
+          ),
+        ],
+        warning: [],
+        summary: {
+          criticalCount: 1,
+          warningCount: 0,
+        },
+      });
+    }
+  }
+
+  return buildValidationResult(slides);
+}
+
+export async function validateSlides(slidesDir) {
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: 1920, height: 1080 } });
+  const page = await context.newPage();
+
+  try {
+    return await validateSlidesInPage(page, slidesDir);
+  } finally {
+    await browser.close();
+  }
+}

--- a/src/validator/slide-files.js
+++ b/src/validator/slide-files.js
@@ -1,0 +1,23 @@
+import { readdir } from 'node:fs/promises';
+
+import { SLIDE_FILE_PATTERN } from './constants.js';
+
+function toSlideOrder(fileName) {
+  const match = fileName.match(/\d+/);
+  return match ? Number.parseInt(match[0], 10) : Number.POSITIVE_INFINITY;
+}
+
+export function sortSlideFiles(a, b) {
+  const orderA = toSlideOrder(a);
+  const orderB = toSlideOrder(b);
+  if (orderA !== orderB) return orderA - orderB;
+  return a.localeCompare(b);
+}
+
+export async function findSlideFiles(slidesDir) {
+  const entries = await readdir(slidesDir, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && SLIDE_FILE_PATTERN.test(entry.name))
+    .map((entry) => entry.name)
+    .sort(sortSlideFiles);
+}

--- a/tests/fixtures/validator/deck/slide-01-overflow.html
+++ b/tests/fixtures/validator/deck/slide-01-overflow.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Overflow Fixture</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        width: 960px;
+        height: 540px;
+      }
+
+      body {
+        position: relative;
+        overflow: hidden;
+        background: #f6f4ef;
+        font-family: sans-serif;
+      }
+
+      div.panel {
+        position: absolute;
+        left: 840px;
+        top: 420px;
+        width: 180px;
+        height: 160px;
+        background: #d1495b;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="panel"></div>
+  </body>
+</html>

--- a/tests/fixtures/validator/deck/slide-02-text-clipped.html
+++ b/tests/fixtures/validator/deck/slide-02-text-clipped.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Text Clipped Fixture</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        width: 960px;
+        height: 540px;
+      }
+
+      body {
+        position: relative;
+        overflow: hidden;
+        background: #f5fbff;
+        font-family: sans-serif;
+      }
+
+      div.card {
+        position: absolute;
+        left: 80px;
+        top: 80px;
+        width: 360px;
+        height: 120px;
+        padding: 20px;
+        background: #dbeafe;
+      }
+
+      p.copy {
+        margin: 0;
+        height: 72px;
+        overflow: hidden;
+        font-size: 24px;
+        line-height: 1.4;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="card">
+      <p class="copy">
+        This paragraph is intentionally taller than its box so the validator detects clipping after layout.
+      </p>
+    </div>
+  </body>
+</html>

--- a/tests/fixtures/validator/deck/slide-03-sibling-overlap.html
+++ b/tests/fixtures/validator/deck/slide-03-sibling-overlap.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Sibling Overlap Fixture</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        width: 960px;
+        height: 540px;
+      }
+
+      body {
+        position: relative;
+        overflow: hidden;
+        background: #fff9f0;
+        font-family: sans-serif;
+      }
+
+      div.box {
+        position: absolute;
+        width: 220px;
+        height: 140px;
+      }
+
+      div.box-a {
+        left: 160px;
+        top: 140px;
+        background: #00798c;
+      }
+
+      div.box-b {
+        left: 300px;
+        top: 200px;
+        background: #edae49;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="box box-a"></div>
+    <div class="box box-b"></div>
+  </body>
+</html>

--- a/tests/fixtures/validator/deck/slide-04-clean.html
+++ b/tests/fixtures/validator/deck/slide-04-clean.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Clean Fixture</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        width: 960px;
+        height: 540px;
+      }
+
+      body {
+        position: relative;
+        overflow: hidden;
+        background: #f7f7f7;
+        font-family: sans-serif;
+      }
+
+      div.card {
+        position: absolute;
+        left: 120px;
+        top: 100px;
+        width: 320px;
+        height: 180px;
+        padding: 24px;
+        background: #ffffff;
+      }
+
+      h1 {
+        margin: 0 0 12px;
+        font-size: 32px;
+      }
+
+      p {
+        margin: 0;
+        font-size: 20px;
+        line-height: 1.4;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="card">
+      <h1>Validator Fixture</h1>
+      <p>This slide should pass without warnings.</p>
+    </div>
+  </body>
+</html>

--- a/tests/validator/validate-slides.test.js
+++ b/tests/validator/validate-slides.test.js
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { after, before, test } from 'node:test';
+
+import { chromium } from 'playwright';
+
+import {
+  findSlideFiles,
+  inspectSlide,
+  parseCliArgs,
+  sortSlideFiles,
+  validateSlidesInPage,
+} from '../../src/validator/index.js';
+
+const fixturesDir = path.resolve('tests/fixtures/validator/deck');
+
+let browser;
+let context;
+let page;
+
+before(async () => {
+  browser = await chromium.launch({ headless: true });
+  context = await browser.newContext({ viewport: { width: 1920, height: 1080 } });
+  page = await context.newPage();
+});
+
+after(async () => {
+  await browser?.close();
+});
+
+test('parseCliArgs applies defaults and reads slides-dir options', () => {
+  assert.deepEqual(parseCliArgs([]), {
+    slidesDir: 'slides',
+    help: false,
+  });
+  assert.equal(parseCliArgs(['--slides-dir', 'decks/product-a']).slidesDir, 'decks/product-a');
+  assert.equal(parseCliArgs(['--slides-dir=slides-q1']).slidesDir, 'slides-q1');
+});
+
+test('parseCliArgs rejects missing or unknown options', () => {
+  assert.throws(() => parseCliArgs(['--slides-dir']), /missing value/i);
+  assert.throws(() => parseCliArgs(['--bogus']), /unknown option/i);
+});
+
+test('sortSlideFiles keeps numeric order before lexical order', () => {
+  const sorted = ['slide-10.html', 'slide-2.html', 'slide-alpha.html', 'slide-01.html'].sort(
+    sortSlideFiles,
+  );
+  assert.deepEqual(sorted, ['slide-01.html', 'slide-2.html', 'slide-10.html', 'slide-alpha.html']);
+});
+
+test('findSlideFiles returns validator fixtures in sorted order', async () => {
+  const files = await findSlideFiles(fixturesDir);
+  assert.deepEqual(files, [
+    'slide-01-overflow.html',
+    'slide-02-text-clipped.html',
+    'slide-03-sibling-overlap.html',
+    'slide-04-clean.html',
+  ]);
+});
+
+test('inspectSlide reports overflow-outside-frame as a critical failure', async () => {
+  const result = await inspectSlide(page, 'slide-01-overflow.html', fixturesDir);
+
+  assert.equal(result.status, 'fail');
+  assert.equal(result.summary.criticalCount, 1);
+  assert.equal(result.critical[0].code, 'overflow-outside-frame');
+  assert.match(result.critical[0].element, /div\.panel/);
+});
+
+test('inspectSlide reports text clipping as a critical failure', async () => {
+  const result = await inspectSlide(page, 'slide-02-text-clipped.html', fixturesDir);
+
+  assert.equal(result.status, 'fail');
+  assert.equal(result.summary.criticalCount, 1);
+  assert.equal(result.critical[0].code, 'text-clipped');
+  assert.match(result.critical[0].element, /p\.copy/);
+  assert.ok(result.critical[0].metrics.scrollHeight > result.critical[0].metrics.clientHeight);
+});
+
+test('inspectSlide reports sibling overlap as a warning without failing the slide', async () => {
+  const result = await inspectSlide(page, 'slide-03-sibling-overlap.html', fixturesDir);
+
+  assert.equal(result.status, 'pass');
+  assert.equal(result.summary.criticalCount, 0);
+  assert.equal(result.summary.warningCount, 1);
+  assert.equal(result.warning[0].code, 'sibling-overlap');
+});
+
+test('validateSlidesInPage preserves slide status and summary semantics across fixtures', async () => {
+  const report = await validateSlidesInPage(page, fixturesDir);
+
+  assert.deepEqual(report.slides.map((slide) => [slide.slide, slide.status]), [
+    ['slide-01-overflow.html', 'fail'],
+    ['slide-02-text-clipped.html', 'fail'],
+    ['slide-03-sibling-overlap.html', 'pass'],
+    ['slide-04-clean.html', 'pass'],
+  ]);
+  assert.deepEqual(report.summary, {
+    totalSlides: 4,
+    passedSlides: 2,
+    failedSlides: 2,
+    criticalIssues: 2,
+    warnings: 1,
+  });
+});


### PR DESCRIPTION
## Summary
- extract reusable slide validation logic from the CLI into stable  modules
- keep  as a thin wrapper that preserves current JSON and exit semantics
- add fixture-backed coverage for overflow, text clipping, sibling overlap, and aggregate summary behavior

## Testing
- npm test
- node scripts/validate-slides.js --slides-dir tests/fixtures/validator/deck

Closes #9