### PR TITLE
docs: clarify pdf export diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ slides-grab list-themes       # Show available color themes
 
 `slides-grab pdf` now defaults to `--mode capture`, which rasterizes each rendered slide into the PDF for better visual fidelity. Use `--mode print` when searchable/selectable browser text matters more than pixel-perfect parity.
 
+When export hits browser-side problems, `slides-grab pdf` prints slide-specific diagnostics to stderr, including console warnings/errors, page errors, and failed asset requests. That makes it easier to trace broken fonts, images, or scripts back to the exact `slide-*.html` file.
+
 ### Multi-Deck Workflow
 
 Prerequisite: create or generate a deck in `decks/my-deck/` first.

--- a/docs/installation/claude.md
+++ b/docs/installation/claude.md
@@ -49,6 +49,8 @@ slides-grab figma --slides-dir decks/my-deck --output decks/my-deck-figma.pptx
 
 `slides-grab pdf` defaults to `--mode capture` for visual fidelity. Use `--mode print` when searchable/selectable text is more important than pixel-perfect browser parity.
 
+If export surfaces browser warnings, page errors, or failed requests, the CLI prints them as slide-specific diagnostics on stderr so you can see which `slide-*.html` needs attention.
+
 ## 4) Recommended Claude Kickoff Prompt
 
 Copy-paste into Claude:

--- a/docs/installation/codex.md
+++ b/docs/installation/codex.md
@@ -51,6 +51,8 @@ slides-grab figma --slides-dir decks/my-deck --output decks/my-deck-figma.pptx
 
 `slides-grab pdf` defaults to `--mode capture` for browser-faithful rendering. Switch to `--mode print` when you need searchable/selectable text in the exported PDF.
 
+If export hits browser warnings, page errors, or failed requests, the CLI reports them as slide-specific diagnostics on stderr so you can fix the exact `slide-*.html` involved.
+
 ## 4) Recommended Codex Kickoff Prompt
 
 Copy-paste into Codex:

--- a/docs/prompts/setup-claude.md
+++ b/docs/prompts/setup-claude.md
@@ -45,4 +45,6 @@ Use `decks/<deck-name>/` as the slides workspace. Default is `slides/`.
 
 `--mode capture` is the default for browser-faithful output. `--mode print` keeps searchable/selectable PDF text.
 
+If PDF export logs diagnostics on stderr, inspect the named slide file first. The exporter now reports browser warnings/errors and failed requests per slide.
+
 Setup complete. Ready to create presentations.

--- a/docs/prompts/setup-codex.md
+++ b/docs/prompts/setup-codex.md
@@ -53,4 +53,6 @@ Use `decks/<deck-name>/` as the slides workspace. Default is `slides/`.
 
 `--mode capture` maximizes visual fidelity. `--mode print` keeps searchable/selectable PDF text.
 
+If PDF export prints diagnostics on stderr, start with the referenced slide file. The exporter now reports browser warnings/errors and failed requests per slide.
+
 Setup complete. Ready to create presentations.


### PR DESCRIPTION
## Summary
- document that  emits slide-specific diagnostics on stderr
- keep the existing  default and  mode guidance intact in user-facing docs
- update README plus Claude/Codex setup docs where users look up PDF export behavior

## Verification
- Usage: slides-grab pdf [options]

Convert slide HTML files to PDF

Options:
  --slides-dir <path>  Slide directory (default: "slides")
  --output <path>      Output PDF file
  --mode <mode>        PDF export mode: capture for visual fidelity, print for
                       searchable text (default: "capture")
  -h, --help           display help for command

Related #10