### PR TITLE
fix: stabilize pdf frame isolation after render readiness

### DIFF
--- a/scripts/html2pdf.js
+++ b/scripts/html2pdf.js
@@ -229,9 +229,10 @@ function chooseSlideFrame(metrics) {
 
 export async function waitForSlideRenderReady(page, options = {}) {
   const settleMs = normalizeDimension(options.settleMs ?? RENDER_SETTLE_MS, RENDER_SETTLE_MS);
+  const shouldRunReadySignal = options.runReadySignal !== false;
 
   await page.waitForLoadState('load');
-  await page.evaluate(async ({ settleMs: settleDelay }) => {
+  await page.evaluate(async ({ settleMs: settleDelay, runReadySignal }) => {
     if (document.fonts?.ready) {
       await document.fonts.ready.catch(() => {});
     }
@@ -255,28 +256,30 @@ export async function waitForSlideRenderReady(page, options = {}) {
       }),
     );
 
-    const readySignal =
-      window.__slidesGrabReady ??
-      window.__SLIDES_GRAB_READY ??
-      window.slidesGrabReady ??
-      document.documentElement?.dataset?.slidesGrabReady ??
-      document.body?.dataset?.slidesGrabReady;
+    if (runReadySignal) {
+      const readySignal =
+        window.__slidesGrabReady ??
+        window.__SLIDES_GRAB_READY ??
+        window.slidesGrabReady ??
+        document.documentElement?.dataset?.slidesGrabReady ??
+        document.body?.dataset?.slidesGrabReady;
 
-    if (typeof readySignal === 'function') {
-      await readySignal();
-    } else if (readySignal && typeof readySignal.then === 'function') {
-      await readySignal.catch(() => {});
-    } else if (readySignal === 'pending') {
-      await new Promise((resolve) => {
-        const listener = () => resolve();
-        window.addEventListener('slides-grab-ready', listener, { once: true });
-        setTimeout(resolve, 5000);
-      });
+      if (typeof readySignal === 'function') {
+        await readySignal();
+      } else if (readySignal && typeof readySignal.then === 'function') {
+        await readySignal.catch(() => {});
+      } else if (readySignal === 'pending') {
+        await new Promise((resolve) => {
+          const listener = () => resolve();
+          window.addEventListener('slides-grab-ready', listener, { once: true });
+          setTimeout(resolve, 5000);
+        });
+      }
     }
 
     await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
     await new Promise((resolve) => setTimeout(resolve, settleDelay));
-  }, { settleMs });
+  }, { settleMs, runReadySignal: shouldRunReadySignal });
 }
 
 export async function detectSlideFrame(page) {
@@ -382,6 +385,8 @@ export async function isolateSlideFrame(page, slideFrame) {
     translatedContent.style.width = `${Math.max(width + x, body.scrollWidth, document.documentElement.scrollWidth)}px`;
     translatedContent.style.height = `${Math.max(height + y, body.scrollHeight, document.documentElement.scrollHeight)}px`;
 
+    // Preserve the original node order inside one translated subtree so overlap
+    // paint order and live DOM state survive both capture and print exports.
     const childNodes = Array.from(body.childNodes);
     body.replaceChildren(clipFrame);
     clipFrame.append(translatedContent);
@@ -459,7 +464,7 @@ export async function renderSlideToPdf(page, slideFile, slidesDir, options = {})
   const slideFrame = await detectSlideFrame(page);
   const normalizedSlideFrame = await isolateSlideFrame(page, slideFrame);
   await normalizeBodyToSlideFrame(page, normalizedSlideFrame);
-  await waitForSlideRenderReady(page, options);
+  await waitForSlideRenderReady(page, { ...options, runReadySignal: false });
 
   if (mode === 'capture') {
     const viewportSize = {
@@ -467,7 +472,7 @@ export async function renderSlideToPdf(page, slideFile, slidesDir, options = {})
       height: normalizeDimension(normalizedSlideFrame.height, FALLBACK_SLIDE_SIZE.height),
     };
     await page.setViewportSize(viewportSize);
-    await waitForSlideRenderReady(page, options);
+    await waitForSlideRenderReady(page, { ...options, runReadySignal: false });
     const pngBytes = await page.screenshot({
       type: 'png',
       clip: {

--- a/tests/pdf/fixtures/overlapping-frame-siblings/slide-01.html
+++ b/tests/pdf/fixtures/overlapping-frame-siblings/slide-01.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+      background: #FFFFFF;
+    }
+
+    body {
+      position: relative;
+    }
+  </style>
+</head>
+<body>
+  <div style="position: absolute; left: 0; top: 0; width: 240px; height: 240px; background: #0047FF;"></div>
+  <div
+    id="frame"
+    style="position: absolute; left: 0; top: 0; width: 960px; height: 540px; overflow: hidden; background: #F8F5EC;"
+  >
+    <div style="position: absolute; left: 0; top: 0; width: 120px; height: 120px; background: #E65000;"></div>
+    <div style="position: absolute; left: 48px; top: 160px;">
+      <h1 style="margin: 0; font-family: Arial, sans-serif; font-size: 42px; color: #121212;">Overlap Order</h1>
+      <p style="margin: 24px 0 0; font-family: Arial, sans-serif; font-size: 26px; color: #121212;">Frame content should stay on top.</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/tests/pdf/fixtures/runtime-direct-child-frame/slide-01.html
+++ b/tests/pdf/fixtures/runtime-direct-child-frame/slide-01.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+      background: #FFFFFF;
+    }
+
+    body {
+      position: relative;
+    }
+  </style>
+</head>
+<body>
+  <div
+    id="frame"
+    style="position: absolute; left: 200px; top: 120px; width: 960px; height: 540px; overflow: hidden; background: #F8F5EC;"
+  >
+    <canvas id="paint" width="960" height="540" style="display: block;"></canvas>
+  </div>
+  <div style="position: absolute; left: 1180px; top: 120px; width: 220px; height: 540px; background: #0047FF;"></div>
+  <script>
+    const frame = document.getElementById('frame');
+    const canvas = document.getElementById('paint');
+    const context = canvas.getContext('2d');
+
+    async function paint() {
+      const frameIsDirectChild = frame.parentElement === document.body;
+
+      context.fillStyle = '#F8F5EC';
+      context.fillRect(0, 0, canvas.width, canvas.height);
+
+      context.fillStyle = frameIsDirectChild ? '#E65000' : '#00C853';
+      context.fillRect(0, 0, 120, 120);
+
+      context.fillStyle = '#0047FF';
+      context.fillRect(canvas.width - 120, 0, 120, 120);
+
+      context.fillStyle = '#121212';
+      context.font = '48px Arial';
+      context.fillText(frameIsDirectChild ? 'Direct Child Preserved' : 'Frame Reparented', 48, 180);
+
+      await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+    }
+
+    window.__slidesGrabReady = paint;
+  </script>
+</body>
+</html>

--- a/tests/pdf/html2pdf.e2e.test.js
+++ b/tests/pdf/html2pdf.e2e.test.js
@@ -14,6 +14,8 @@ import { renderSlideToPdf } from '../../scripts/html2pdf.js';
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 const OFFSET_FRAME_FIXTURE_DIR = join(REPO_ROOT, 'tests', 'pdf', 'fixtures', 'offset-frame');
 const RUNTIME_DIRECT_CHILD_FIXTURE_DIR = join(REPO_ROOT, 'tests', 'pdf', 'fixtures', 'runtime-direct-child');
+const RUNTIME_DIRECT_CHILD_FRAME_FIXTURE_DIR = join(REPO_ROOT, 'tests', 'pdf', 'fixtures', 'runtime-direct-child-frame');
+const OVERLAPPING_FRAME_SIBLINGS_FIXTURE_DIR = join(REPO_ROOT, 'tests', 'pdf', 'fixtures', 'overlapping-frame-siblings');
 const SAME_FRAME_SIBLINGS_FIXTURE_DIR = join(REPO_ROOT, 'tests', 'pdf', 'fixtures', 'same-frame-siblings');
 const TRANSFORMED_FRAME_FIXTURE_DIR = join(REPO_ROOT, 'tests', 'pdf', 'fixtures', 'transformed-frame');
 
@@ -192,6 +194,18 @@ async function copyOffsetFrameFixture(workspace) {
 async function copyRuntimeDirectChildFixture(workspace) {
   const slidesDir = join(workspace, 'slides');
   await cp(RUNTIME_DIRECT_CHILD_FIXTURE_DIR, slidesDir, { recursive: true });
+  return slidesDir;
+}
+
+async function copyRuntimeDirectChildFrameFixture(workspace) {
+  const slidesDir = join(workspace, 'slides');
+  await cp(RUNTIME_DIRECT_CHILD_FRAME_FIXTURE_DIR, slidesDir, { recursive: true });
+  return slidesDir;
+}
+
+async function copyOverlappingFrameSiblingsFixture(workspace) {
+  const slidesDir = join(workspace, 'slides');
+  await cp(OVERLAPPING_FRAME_SIBLINGS_FIXTURE_DIR, slidesDir, { recursive: true });
   return slidesDir;
 }
 
@@ -410,6 +424,112 @@ test('print mode preserves JS-painted direct-child canvas frames', { concurrency
 
     assertPixelApproximately(leftSample.pixel, [230, 80, 0], 12);
     assertPixelApproximately(rightSample.pixel, [0, 71, 255], 12);
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test('capture mode preserves runtime-painted direct-child frame roots during isolation', { concurrency: false, timeout: 120000 }, async () => {
+  const workspace = await mkdtemp(join(os.tmpdir(), 'html2pdf-e2e-runtime-frame-capture-'));
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage({
+    viewport: { width: 960, height: 540 },
+  });
+
+  try {
+    const slidesDir = await copyRuntimeDirectChildFrameFixture(workspace);
+    const result = await renderSlideToPdf(page, 'slide-01.html', slidesDir, { mode: 'capture' });
+
+    const leftPixel = await sharp(result.pngBytes)
+      .extract({ left: 32, top: 32, width: 1, height: 1 })
+      .raw()
+      .toBuffer();
+    const rightPixel = await sharp(result.pngBytes)
+      .extract({ left: result.width - 32, top: 32, width: 1, height: 1 })
+      .raw()
+      .toBuffer();
+
+    assertPixelApproximately(Array.from(leftPixel), [230, 80, 0]);
+    assertPixelApproximately(Array.from(rightPixel), [0, 71, 255]);
+  } finally {
+    await browser.close();
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test('print mode preserves runtime-painted direct-child frame roots during isolation', { concurrency: false, timeout: 120000 }, async (t) => {
+  if (!canRasterizePdfPages()) {
+    t.skip('pdftoppm is required for rendered-image verification');
+  }
+
+  const workspace = await mkdtemp(join(os.tmpdir(), 'html2pdf-e2e-runtime-frame-print-'));
+
+  try {
+    await copyRuntimeDirectChildFrameFixture(workspace);
+    const outputPath = join(workspace, 'runtime-direct-child-frame.pdf');
+    const rasterPrefix = join(workspace, 'runtime-direct-child-frame-page-1');
+
+    const result = await runPdfExport(['--slides-dir', 'slides', '--mode', 'print', '--output', outputPath], workspace);
+    assert.match(result.stdout, /Generated PDF \(print mode\)/);
+
+    const bytes = await readFile(outputPath);
+    const pdf = await PDFDocument.load(bytes);
+    assert.equal(pdf.getPageCount(), 1);
+    assert.deepEqual(getPageSize(pdf.getPages()[0]), { width: 720, height: 405 });
+
+    const pngPath = await rasterizePdfPage(outputPath, rasterPrefix, 1);
+    const leftSample = await readRelativePixel(pngPath, 0.035, 0.06);
+    const rightSample = await readRelativePixel(pngPath, 0.965, 0.06);
+
+    assertPixelApproximately(leftSample.pixel, [230, 80, 0], 12);
+    assertPixelApproximately(rightSample.pixel, [0, 71, 255], 12);
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test('capture mode preserves original overlap order for same-frame body siblings', { concurrency: false, timeout: 120000 }, async () => {
+  const workspace = await mkdtemp(join(os.tmpdir(), 'html2pdf-e2e-overlap-capture-'));
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage({
+    viewport: { width: 960, height: 540 },
+  });
+
+  try {
+    const slidesDir = await copyOverlappingFrameSiblingsFixture(workspace);
+    const result = await renderSlideToPdf(page, 'slide-01.html', slidesDir, { mode: 'capture' });
+
+    const overlapPixel = await sharp(result.pngBytes)
+      .extract({ left: 32, top: 32, width: 1, height: 1 })
+      .raw()
+      .toBuffer();
+
+    assertPixelApproximately(Array.from(overlapPixel), [230, 80, 0], 12);
+  } finally {
+    await browser.close();
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test('print mode preserves original overlap order for same-frame body siblings', { concurrency: false, timeout: 120000 }, async (t) => {
+  if (!canRasterizePdfPages()) {
+    t.skip('pdftoppm is required for rendered-image verification');
+  }
+
+  const workspace = await mkdtemp(join(os.tmpdir(), 'html2pdf-e2e-overlap-print-'));
+
+  try {
+    await copyOverlappingFrameSiblingsFixture(workspace);
+    const outputPath = join(workspace, 'overlapping-frame-siblings.pdf');
+    const rasterPrefix = join(workspace, 'overlapping-frame-siblings-page-1');
+
+    const result = await runPdfExport(['--slides-dir', 'slides', '--mode', 'print', '--output', outputPath], workspace);
+    assert.match(result.stdout, /Generated PDF \(print mode\)/);
+
+    const pngPath = await rasterizePdfPage(outputPath, rasterPrefix, 1);
+    const overlapSample = await readRelativePixel(pngPath, 0.035, 0.06);
+
+    assertPixelApproximately(overlapSample.pixel, [230, 80, 0], 12);
   } finally {
     await rm(workspace, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- stop rerunning custom slide ready hooks after export-only DOM isolation and viewport normalization
- add direct-child frame-root PDF regressions for capture and print exports
- add overlap-order PDF regressions so sibling stacking stays stable during frame isolation

## Verification
- node --test tests/pdf/html2pdf.test.js tests/pdf/html2pdf.e2e.test.js
- npm test