### PR TITLE
fix: address PR #15 QA follow-up regressions

### DIFF
--- a/convert.cjs
+++ b/convert.cjs
@@ -5,9 +5,6 @@ const fs = require('fs');
 const sharp = require('sharp');
 
 // Inline a simplified version that uses Playwright Chromium (not Chrome)
-const PT_PER_PX = 0.75;
-const PX_PER_IN = 96;
-const EMU_PER_IN = 914400;
 const DEFAULT_SLIDES_DIR = 'slides';
 const DEFAULT_OUTPUT = 'output.pptx';
 
@@ -109,9 +106,9 @@ async function convertSlide(htmlFile, pres, browser) {
   const screenshot = await page.screenshot({ type: 'png' });
   await page.close();
 
-  // Resize to exact slide dimensions (13.33" x 7.5" at 150 DPI)
-  const targetWidth = Math.round(13.33 * 150);
-  const targetHeight = Math.round(7.5 * 150);
+  // Match the defined PowerPoint layout so 720pt x 405pt decks stay at the repo standard size.
+  const targetWidth = Math.round((pres.presLayout.width / 914400) * 150);
+  const targetHeight = Math.round((pres.presLayout.height / 914400) * 150);
 
   const resized = await sharp(screenshot)
     .resize(targetWidth, targetHeight, { fit: 'fill' })
@@ -140,8 +137,9 @@ async function main() {
     return;
   }
 
+  const { configureStandardPresentation, ensureOutputDirectory } = await import('./src/figma.js');
   const pres = new PptxGenJS();
-  pres.layout = 'LAYOUT_WIDE'; // 16:9
+  configureStandardPresentation(pres);
 
   const slidesDir = path.resolve(process.cwd(), options.slidesDir);
   const files = fs.readdirSync(slidesDir)
@@ -169,6 +167,7 @@ async function main() {
   await browser.close();
 
   const outputFile = path.resolve(process.cwd(), options.output);
+  await ensureOutputDirectory(outputFile);
   await pres.writeFile({ fileName: outputFile });
   console.log(`\nSaved: ${outputFile}`);
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "validate": "node scripts/validate-slides.js",
     "convert": "node convert.cjs",
     "codex:install-skills": "node scripts/install-codex-skills.js --force",
-    "test": "node --test tests/editor/editor-codex-edit.test.js tests/pdf/html2pdf.test.js tests/pdf/html2pdf.e2e.test.js tests/figma/figma-export.test.js tests/validation/validate-slides.test.js",
+    "test": "node --test tests/editor/editor-codex-edit.test.js tests/pdf/html2pdf.test.js tests/pdf/html2pdf.e2e.test.js tests/figma/figma-export.test.js tests/convert/convert-cli.test.js tests/validation/validate-slides.test.js",
     "test:e2e": "node --test tests/editor/editor-ui.e2e.test.js tests/editor/editor-concurrency.e2e.test.js"
   },
   "dependencies": {

--- a/scripts/figma-export.js
+++ b/scripts/figma-export.js
@@ -10,6 +10,7 @@ import {
   configureFigmaExportPresentation,
   ensureOutputDirectory,
   getFigmaImportCaveats,
+  getFigmaManualImportInstructions,
   normalizeFigmaOutput,
   SLIDE_FILE_PATTERN,
   sortFigmaSlideFiles,
@@ -138,7 +139,7 @@ async function main() {
   for (const caveat of getFigmaImportCaveats()) {
     console.log(`- ${caveat}`);
   }
-  console.log('\nManual import: Figma Slides -> Import -> select the generated .pptx file.');
+  console.log(`\nManual import: ${getFigmaManualImportInstructions()}`);
 }
 
 main().catch((error) => {

--- a/scripts/html2pptx.js
+++ b/scripts/html2pptx.js
@@ -6,7 +6,12 @@ import { resolve } from 'node:path';
 
 import PptxGenJS from 'pptxgenjs';
 
-import { ensureOutputDirectory, SLIDE_FILE_PATTERN, sortFigmaSlideFiles } from '../src/figma.js';
+import {
+  configureStandardPresentation,
+  ensureOutputDirectory,
+  SLIDE_FILE_PATTERN,
+  sortFigmaSlideFiles,
+} from '../src/figma.js';
 
 const require = createRequire(import.meta.url);
 const html2pptx = require('../src/html2pptx.cjs');
@@ -116,7 +121,7 @@ async function main() {
   const files = getHtmlSlides(slidesDir);
 
   const pres = new PptxGenJS();
-  pres.layout = 'LAYOUT_WIDE';
+  configureStandardPresentation(pres);
 
   for (const file of files) {
     await html2pptx(resolve(slidesDir, file), pres);

--- a/src/figma.js
+++ b/src/figma.js
@@ -3,7 +3,8 @@ import { basename, dirname, extname, join, resolve } from 'node:path';
 
 export const DEFAULT_FIGMA_SUFFIX = '-figma.pptx';
 export const SLIDE_FILE_PATTERN = /^slide-.*\.html$/i;
-export const FIGMA_EXPORT_LAYOUT_NAME = 'SLIDES_GRAB_STANDARD';
+export const REPO_STANDARD_LAYOUT_NAME = 'SLIDES_GRAB_STANDARD';
+export const FIGMA_EXPORT_LAYOUT_NAME = REPO_STANDARD_LAYOUT_NAME;
 export const SLIDE_WIDTH_INCHES = 10;
 export const SLIDE_HEIGHT_INCHES = 5.625;
 
@@ -36,14 +37,18 @@ export function getFigmaManualImportInstructions() {
   return 'Figma Slides -> Import -> select the generated .pptx file.';
 }
 
-export function configureFigmaExportPresentation(pres) {
+export function configureStandardPresentation(pres) {
   pres.defineLayout({
-    name: FIGMA_EXPORT_LAYOUT_NAME,
+    name: REPO_STANDARD_LAYOUT_NAME,
     width: SLIDE_WIDTH_INCHES,
     height: SLIDE_HEIGHT_INCHES,
   });
-  pres.layout = FIGMA_EXPORT_LAYOUT_NAME;
+  pres.layout = REPO_STANDARD_LAYOUT_NAME;
   return pres;
+}
+
+export function configureFigmaExportPresentation(pres) {
+  return configureStandardPresentation(pres);
 }
 
 export async function ensureOutputDirectory(outputFile) {

--- a/tests/convert/convert-cli.test.js
+++ b/tests/convert/convert-cli.test.js
@@ -1,0 +1,115 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { inflateRawSync } from 'node:zlib';
+
+test('slides-grab convert creates missing parent directories and preserves repo-standard deck size', () => {
+  const root = mkdtempSync(join(tmpdir(), 'slides-grab-convert-cli-'));
+  const slidesDir = join(root, 'slides');
+  const outputPath = join(root, 'nested', 'exports', 'deck.pptx');
+
+  try {
+    mkdirSync(slidesDir, { recursive: true });
+    writeFileSync(join(slidesDir, 'slide-01.html'), createTestSlideHtml(), 'utf-8');
+
+    execFileSync(
+      process.execPath,
+      [
+        'bin/ppt-agent.js',
+        'convert',
+        '--slides-dir',
+        slidesDir,
+        '--output',
+        outputPath,
+      ],
+      {
+        cwd: process.cwd(),
+        encoding: 'utf-8',
+      },
+    );
+
+    assert.equal(existsSync(outputPath), true);
+
+    const presentationXml = extractZipEntry(readFileSync(outputPath), 'ppt/presentation.xml').toString('utf-8');
+    assert.match(presentationXml, /cx="9144000"/);
+    assert.match(presentationXml, /cy="5143500"/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function extractZipEntry(zipBuffer, entryName) {
+  let offset = 0;
+
+  while (offset + 30 <= zipBuffer.length) {
+    const signature = zipBuffer.readUInt32LE(offset);
+    if (signature !== 0x04034b50) {
+      break;
+    }
+
+    const compressionMethod = zipBuffer.readUInt16LE(offset + 8);
+    const compressedSize = zipBuffer.readUInt32LE(offset + 18);
+    const fileNameLength = zipBuffer.readUInt16LE(offset + 26);
+    const extraFieldLength = zipBuffer.readUInt16LE(offset + 28);
+    const fileNameStart = offset + 30;
+    const fileNameEnd = fileNameStart + fileNameLength;
+    const dataStart = fileNameEnd + extraFieldLength;
+    const dataEnd = dataStart + compressedSize;
+    const fileName = zipBuffer.subarray(fileNameStart, fileNameEnd).toString('utf-8');
+
+    if (fileName === entryName) {
+      const payload = zipBuffer.subarray(dataStart, dataEnd);
+      if (compressionMethod === 0) return payload;
+      if (compressionMethod === 8) return inflateRawSync(payload);
+      throw new Error(`Unsupported ZIP compression method ${compressionMethod} for ${entryName}`);
+    }
+
+    offset = dataEnd;
+  }
+
+  throw new Error(`ZIP entry not found: ${entryName}`);
+}
+
+function createTestSlideHtml() {
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    * { box-sizing: border-box; }
+    body {
+      width: 720pt;
+      height: 405pt;
+      margin: 0;
+      padding: 36pt;
+      font-family: Pretendard, sans-serif;
+      background: #ffffff;
+    }
+    .frame {
+      width: 100%;
+      height: 100%;
+      border: 1pt solid #222222;
+      padding: 24pt;
+    }
+    h1 {
+      margin: 0 0 12pt;
+      font-size: 24pt;
+      color: #111111;
+    }
+    p {
+      margin: 0;
+      font-size: 14pt;
+      color: #444444;
+    }
+  </style>
+</head>
+<body>
+  <div class="frame">
+    <h1>Convert Export Proof</h1>
+    <p>Repo-standard slide dimensions should be preserved.</p>
+  </div>
+</body>
+</html>`;
+}

--- a/tests/figma/figma-export.test.js
+++ b/tests/figma/figma-export.test.js
@@ -11,11 +11,13 @@ import PptxGenJS from 'pptxgenjs';
 import {
   buildDefaultFigmaOutput,
   configureFigmaExportPresentation,
+  configureStandardPresentation,
   ensureOutputDirectory,
   FIGMA_EXPORT_LAYOUT_NAME,
   getFigmaImportCaveats,
   getFigmaManualImportInstructions,
   normalizeFigmaOutput,
+  REPO_STANDARD_LAYOUT_NAME,
   SLIDE_HEIGHT_INCHES,
   SLIDE_WIDTH_INCHES,
   sortFigmaSlideFiles,
@@ -89,6 +91,15 @@ test('configureFigmaExportPresentation applies the repo-standard slide size', ()
   assert.equal(pres.presLayout.height / 914400, SLIDE_HEIGHT_INCHES);
 });
 
+test('configureStandardPresentation applies the repo-standard slide size', () => {
+  const pres = new PptxGenJS();
+  configureStandardPresentation(pres);
+
+  assert.equal(pres.layout, REPO_STANDARD_LAYOUT_NAME);
+  assert.equal(pres.presLayout.width / 914400, SLIDE_WIDTH_INCHES);
+  assert.equal(pres.presLayout.height / 914400, SLIDE_HEIGHT_INCHES);
+});
+
 test('figma exporter generates a pptx with the repo-standard presentation size', () => {
   const outputDir = mkdtempSync(join(tmpdir(), 'slides-grab-figma-export-'));
   const slidesDir = join(outputDir, 'slides');
@@ -96,7 +107,7 @@ test('figma exporter generates a pptx with the repo-standard presentation size',
 
   try {
     mkdirSync(slidesDir, { recursive: true });
-    writeFileSync(join(outputDir, 'slides', 'slide-01.html'), createTestSlideHtml(), 'utf-8');
+    writeFileSync(join(slidesDir, 'slide-01.html'), createTestSlideHtml(), 'utf-8');
 
     execFileSync(
       process.execPath,


### PR DESCRIPTION
## Summary
- expose Figma manual-import guidance and caveats from \
- create missing parent directories before writing PPTX outputs
- use the repo-standard 720pt x 405pt layout instead of hardcoded \ for PPTX exports
- add regression coverage for figma help/output behavior and standard convert export sizing

## Verification
- \Usage: slides-grab figma [options]

Export a Figma Slides importable PPTX

Options:
  --slides-dir <path>  Slide directory (default: "slides")
  --output <path>      Output PPTX file (default: <slides-dir>-figma.pptx)
  -h, --help           Show this help message

Creates a PowerPoint file tuned for Figma Slides manual import.

Manual import:
  Figma Slides -> Import -> select the generated .pptx file.

Figma import caveats:
  - Figma imports PPTX best-effort. Complex layouts, shadows, and grouped elements can shift or flatten.
  - Fonts are resolved inside Figma. If Pretendard is unavailable there, expect substitution and reflow.
  - Import is one-way. Re-importing creates a new Figma Slides file instead of updating the existing one.
  - Review every imported slide, especially chart-heavy slides and text near slide edges.
- \✔ slides-grab convert creates missing parent directories and preserves repo-standard deck size (497.308292ms)
✔ buildDefaultFigmaOutput places figma pptx next to slides dir (0.789958ms)
✔ normalizeFigmaOutput appends .pptx when omitted (0.114167ms)
✔ getFigmaImportCaveats returns user-facing warnings (0.192542ms)
✔ ensureOutputDirectory creates missing parent directories for nested output paths (2.419291ms)
✔ sortFigmaSlideFiles orders slide html files numerically (0.634875ms)
✔ slides-grab help lists the figma command (55.33275ms)
✔ figma command help documents manual import intent (56.425625ms)
✔ configureFigmaExportPresentation applies the repo-standard slide size (0.237208ms)
✔ configureStandardPresentation applies the repo-standard slide size (0.073417ms)
✔ figma exporter generates a pptx with the repo-standard presentation size (1479.986292ms)
✔ slides-grab figma creates missing parent directories for nested output paths (1532.527792ms)
✔ npm pack includes packaged html2pptx runtime instead of relying on .claude assets (216.842125ms)
✔ packed npm install can execute slides-grab figma without missing runtime modules (3160.32725ms)
ℹ tests 14
ℹ suites 0
ℹ pass 14
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 6588.574792
- \
> slides-grab@1.0.0 test
> node --test tests/editor/editor-codex-edit.test.js tests/pdf/html2pdf.test.js tests/pdf/html2pdf.e2e.test.js tests/figma/figma-export.test.js tests/convert/convert-cli.test.js tests/validation/validate-slides.test.js

✔ slides-grab convert creates missing parent directories and preserves repo-standard deck size (503.205833ms)
✔ normalizeSelection rounds values and clamps to slide bounds (1.204333ms)
✔ scaleSelectionToScreenshot maps slide bbox to screenshot pixels (0.084792ms)
✔ buildCodexEditPrompt includes user prompt, bbox, and XPath targets (0.362625ms)
✔ buildCodexEditPrompt uses explicit slide path when provided (0.07025ms)
✔ buildCodexExecArgs attaches image and prompt to codex exec (0.088959ms)
✔ buildDefaultFigmaOutput places figma pptx next to slides dir (0.829833ms)
✔ normalizeFigmaOutput appends .pptx when omitted (0.093083ms)
✔ getFigmaImportCaveats returns user-facing warnings (0.105208ms)
✔ ensureOutputDirectory creates missing parent directories for nested output paths (2.742333ms)
✔ sortFigmaSlideFiles orders slide html files numerically (0.785709ms)
✔ slides-grab help lists the figma command (59.792583ms)
✔ figma command help documents manual import intent (62.153083ms)
✔ configureFigmaExportPresentation applies the repo-standard slide size (0.253208ms)
✔ configureStandardPresentation applies the repo-standard slide size (0.07675ms)
✔ figma exporter generates a pptx with the repo-standard presentation size (1515.703166ms)
✔ slides-grab figma creates missing parent directories for nested output paths (1561.76425ms)
✔ npm pack includes packaged html2pptx runtime instead of relying on .claude assets (216.095708ms)
✔ packed npm install can execute slides-grab figma without missing runtime modules (3159.522958ms)
✔ capture mode is the default and produces image-backed pages (1417.344042ms)
✔ print mode keeps searchable browser text flow and normalizes the bleed regression slide size (1186.075291ms)
✔ print mode clips off-canvas bleed fixtures instead of leaving a right gutter (1086.89575ms)
✔ offset-frame fixture keeps capture crops aligned to the detected frame origin (658.387625ms)
✔ offset-frame fixture keeps print exports cropped to the detected frame origin (829.00025ms)
✔ capture mode preserves JS-painted direct-child canvas frames (657.257208ms)
✔ print mode preserves JS-painted direct-child canvas frames (837.813792ms)
✔ capture mode keeps same-frame top-level siblings inside the selected slide frame (803.36375ms)
✔ print mode keeps same-frame top-level siblings inside the selected slide frame (1037.168625ms)
✔ capture mode preserves transformed slide roots during normalization (921.591375ms)
✔ print mode preserves transformed slide roots during normalization (775.770583ms)
✔ parseCliArgs applies defaults for output, slides dir, mode, and help (1.232708ms)
✔ parseCliArgs reads output, slides dir, and mode options (0.096ms)
✔ parseCliArgs rejects missing and invalid option values (0.235041ms)
✔ sortSlideFiles orders by slide number then file name (0.187125ms)
✔ findSlideFiles returns slide-*.html files in sorted order (4.93975ms)
✔ buildPdfOptions preserves backgrounds for print rendering (0.116416ms)
✔ mergePdfBuffers combines all slide pdf pages into one document (8.172792ms)
✔ renderSlideToPdf uses inner wrapper dimensions when body has no slide size (491.468417ms)
✔ buildCapturePdf creates one image-backed page per slide (3.887208ms)
✔ parseValidateCliArgs applies defaults and reads --slides-dir (1.534125ms)
✔ findSlideFiles sorts slide fixtures deterministically (1.619ms)
✔ scanSlides returns stable issue codes for regression fixtures (214.667584ms)
✔ validate CLI preserves JSON result shape for regression fixtures (379.099667ms)
ℹ tests 43
ℹ suites 0
ℹ pass 43
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 10439.898959
