### PR TITLE
Preserve slide body padding during PDF export

### DIFF
--- a/scripts/html2pdf.js
+++ b/scripts/html2pdf.js
@@ -403,7 +403,6 @@ export async function normalizeBodyToSlideFrame(page, slideFrame) {
     const documentElement = document.documentElement;
 
     body.style.margin = '0';
-    body.style.padding = '0';
     body.style.width = `${width}px`;
     body.style.height = `${height}px`;
     body.style.minWidth = `${width}px`;

--- a/tests/pdf/html2pdf.e2e.test.js
+++ b/tests/pdf/html2pdf.e2e.test.js
@@ -317,6 +317,61 @@ test('print mode clips off-canvas bleed fixtures instead of leaving a right gutt
   }
 });
 
+test('print mode preserves body padding used as slide margin', { concurrency: false, timeout: 120000 }, async (t) => {
+  if (!canRasterizePdfPages()) {
+    t.skip('pdftoppm is required for rendered-image verification');
+  }
+
+  const workspace = await mkdtemp(join(os.tmpdir(), 'html2pdf-e2e-body-padding-print-'));
+
+  try {
+    const slidesDir = join(workspace, 'slides');
+    await mkdir(slidesDir, { recursive: true });
+
+    const slideHtml = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      width: 960px;
+      height: 540px;
+      overflow: hidden;
+      padding: 48px 64px;
+      background: #102030;
+      font-family: Helvetica, Arial, sans-serif;
+    }
+    .panel {
+      width: 100%;
+      height: 100%;
+      background: #F4EBD0;
+    }
+  </style>
+</head>
+<body>
+  <div class="panel"></div>
+</body>
+</html>`;
+
+    await writeFile(join(slidesDir, 'slide-01.html'), slideHtml, 'utf8');
+
+    const outputPath = join(workspace, 'body-padding.pdf');
+    const rasterPrefix = join(workspace, 'body-padding-page-1');
+
+    await runPdfExport(['--slides-dir', 'slides', '--mode', 'print', '--output', outputPath], workspace);
+    const pngPath = await rasterizePdfPage(outputPath, rasterPrefix, 1);
+
+    const edgeSample = await readRelativePixel(pngPath, 0.02, 0.5);
+    const innerSample = await readRelativePixel(pngPath, 0.12, 0.5);
+
+    assertPixelApproximately(edgeSample.pixel.slice(0, 3), [16, 32, 48]);
+    assertPixelApproximately(innerSample.pixel.slice(0, 3), [244, 235, 208]);
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
 test('offset-frame fixture keeps capture crops aligned to the detected frame origin', { concurrency: false, timeout: 120000 }, async () => {
   const workspace = await mkdtemp(join(os.tmpdir(), 'html2pdf-e2e-offset-capture-'));
   const browser = await chromium.launch({ headless: true });


### PR DESCRIPTION
## Summary
The PDF exporter zeroes `body` padding during slide-frame normalization, which causes author-defined slide margins to disappear in exported PDFs.

## Repro
1. Create a slide whose `body` uses padding as the slide margin.
2. Export with `slides-grab pdf` / `scripts/html2pdf.js` in capture mode.
3. The exported page edge collapses to the inner panel color instead of preserving the body background margin.

I reproduced the bug from current `origin/main` behavior by restoring the `body.style.padding = '0'` line and verifying the exported raster's left-edge pixels matched the panel color instead of the slide background.

## Fix
- Stop zeroing `body` padding in `normalizeBodyToSlideFrame()`.
- Add an e2e regression test that exports a padded-body slide and verifies the edge/background margin survives print export rasterization.

## Verification
- `node --test tests/pdf/html2pdf.test.js tests/pdf/html2pdf.e2e.test.js`
