### PR TITLE
Feature/#52

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ There are many AI tools that generate slide HTML. Almost none let you **visually
 
 ## CLI Commands
 
-All commands support `--slides-dir <path>` (default: `slides`).
+Workflow commands support `--slides-dir <path>` (default: `slides`). The style discovery commands also accept `--slides-dir <path>` when you want to read/write `style-config.json` inside a specific deck workspace; otherwise they use the current working directory.
 
 On a fresh clone, the discovery commands (`--help`, `list-templates`, `list-themes`, `list-styles`, `preview-styles`, and `select-style`) work without a deck. `edit`, `build-viewer`, `validate`, `convert`, and `pdf` require an existing slides workspace containing `slide-*.html`.
 
@@ -107,7 +107,7 @@ slides-grab select-style glassmorphism
 ```
 
 - Run `slides-grab preview-styles` without `--style` to generate a full local gallery.
-- `slides-grab select-style <id>` writes `style-config.json` in your current workspace so agents can reuse the approved direction before generating slides.
+- `slides-grab select-style <id>` writes `style-config.json` in your current workspace, or inside the `--slides-dir` workspace when you target a specific deck, so agents can reuse the approved direction before generating slides.
 - You can change the selected style anytime before creating or regenerating slides.
 
 This keeps preview/approval in scope without adding a separate GUI: the agent can suggest a few styles, the user previews only when needed, and the approved style is persisted before design work starts.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ There are many AI tools that generate slide HTML. Almost none let you **visually
 
 All commands support `--slides-dir <path>` (default: `slides`).
 
-On a fresh clone, only `--help`, `list-templates`, and `list-themes` work without a deck. `edit`, `build-viewer`, `validate`, `convert`, and `pdf` require an existing slides workspace containing `slide-*.html`.
+On a fresh clone, the discovery commands (`--help`, `list-templates`, `list-themes`, `list-styles`, `preview-styles`, and `select-style`) work without a deck. `edit`, `build-viewer`, `validate`, `convert`, and `pdf` require an existing slides workspace containing `slide-*.html`.
 
 ```bash
 slides-grab edit              # Launch visual slide editor
@@ -89,7 +89,28 @@ slides-grab fetch-video --url <youtube-url> --slides-dir decks/my-deck  # Downlo
 slides-grab tldraw           # Render a .tldr diagram into a slide-sized local SVG asset
 slides-grab list-templates    # Show available slide templates
 slides-grab list-themes       # Show available color themes
+slides-grab list-styles       # Show bundled design collections derived from corazzon/pptx-design-styles
+slides-grab preview-styles --style glassmorphism  # Write a local HTML preview for one style
+slides-grab select-style glassmorphism            # Persist the approved style before generation
 ```
+
+## Design Style Collections
+
+slides-grab bundles 30 design collections derived from [corazzon/pptx-design-styles](https://github.com/corazzon/pptx-design-styles) and preserves the citation in the local preview/config flow.
+
+The simplest workflow stays inside the CLI:
+
+```bash
+slides-grab list-styles
+slides-grab preview-styles --style glassmorphism
+slides-grab select-style glassmorphism
+```
+
+- Run `slides-grab preview-styles` without `--style` to generate a full local gallery.
+- `slides-grab select-style <id>` writes `style-config.json` in your current workspace so agents can reuse the approved direction before generating slides.
+- You can change the selected style anytime before creating or regenerating slides.
+
+This keeps preview/approval in scope without adding a separate GUI: the agent can suggest a few styles, the user previews only when needed, and the approved style is persisted before design work starts.
 
 ## Asset Contract
 

--- a/bin/ppt-agent.js
+++ b/bin/ppt-agent.js
@@ -73,6 +73,24 @@ function reportCliError(error) {
   process.exitCode = 1;
 }
 
+function resolveWorkspaceDir(slidesDir) {
+  if (!slidesDir) {
+    return process.cwd();
+  }
+  return resolve(process.cwd(), String(slidesDir));
+}
+
+function buildSlidesDirSuffix(slidesDir) {
+  return slidesDir ? ` --slides-dir ${slidesDir}` : '';
+}
+
+function formatInvalidStyleSelectionMessage(config) {
+  if (!config?.invalidSelectedStyleId) {
+    return null;
+  }
+  return `Ignoring saved style selection "${config.invalidSelectedStyleId}" from ${config.path}.`;
+}
+
 const program = new Command();
 
 program
@@ -270,14 +288,16 @@ program
 program
   .command('list-styles')
   .description('List bundled design collections users can preview/select before slide generation')
-  .action(async () => {
+  .option('--slides-dir <path>', 'Optional slides workspace used for style-config.json')
+  .action(async (options = {}) => {
     try {
       const [{ listDesignStyles }, { readSelectedStyleConfig }] = await Promise.all([
         import('../src/design-styles.js'),
         import('../src/style-config.js'),
       ]);
+      const workspaceDir = resolveWorkspaceDir(options.slidesDir);
       const styles = listDesignStyles();
-      const selectedConfig = await readSelectedStyleConfig(process.cwd());
+      const selectedConfig = await readSelectedStyleConfig(workspaceDir, { allowInvalidSelection: true });
       const selectedStyleId = selectedConfig?.style?.id ?? null;
 
       if (styles.length === 0) {
@@ -295,8 +315,14 @@ program
       console.log(`\nTotal: ${styles.length} styles`);
       if (selectedConfig?.style) {
         console.log(`Selected style: ${selectedConfig.style.title} (${selectedConfig.style.id})`);
+      } else if (selectedConfig?.invalidSelectedStyleId) {
+        console.log(`Selected style: none (saved value "${selectedConfig.invalidSelectedStyleId}" is no longer bundled)`);
       } else {
         console.log('Selected style: none');
+      }
+      const invalidSelectionMessage = formatInvalidStyleSelectionMessage(selectedConfig);
+      if (invalidSelectionMessage) {
+        console.log(`${invalidSelectionMessage} Run "slides-grab select-style <id>${buildSlidesDirSuffix(options.slidesDir)}" to update it.`);
       }
     } catch (error) {
       reportCliError(error);
@@ -306,18 +332,20 @@ program
 program
   .command('preview-styles')
   .description('Generate a local HTML preview for the full design catalog or one selected style')
+  .option('--slides-dir <path>', 'Optional slides workspace used for style-config.json and default preview output')
   .option('--style <id>', 'Focus the preview on a single style id')
   .option('--output <path>', 'Output HTML path', 'style-preview.html')
   .action(async (options = {}) => {
     try {
       const { buildStylePreviewHtml, requireDesignStyle } = await import('../src/design-styles.js');
       const { readSelectedStyleConfig } = await import('../src/style-config.js');
-      const outputPath = resolve(process.cwd(), options.output);
-      const currentSelection = await readSelectedStyleConfig(process.cwd());
+      const workspaceDir = resolveWorkspaceDir(options.slidesDir);
+      const outputPath = resolve(workspaceDir, options.output);
+      const currentSelection = await readSelectedStyleConfig(workspaceDir, { allowInvalidSelection: true });
       const selectedStyle = options.style ? requireDesignStyle(String(options.style)) : null;
       const html = buildStylePreviewHtml({
         styleId: selectedStyle?.id,
-        selectedStyleId: selectedStyle?.id ?? currentSelection?.selectedStyleId ?? null,
+        selectedStyleId: selectedStyle?.id ?? currentSelection?.style?.id ?? null,
       });
 
       mkdirSync(dirname(outputPath), { recursive: true });
@@ -328,6 +356,10 @@ program
       } else {
         console.log(`Wrote style preview catalog to ${outputPath}`);
       }
+      const invalidSelectionMessage = !selectedStyle ? formatInvalidStyleSelectionMessage(currentSelection) : null;
+      if (invalidSelectionMessage) {
+        console.log(invalidSelectionMessage);
+      }
     } catch (error) {
       reportCliError(error);
     }
@@ -337,20 +369,22 @@ program
   .command('select-style')
   .description('Persist a selected bundled design style before slide generation')
   .argument('<id>', 'Design style id (e.g. "glassmorphism")')
-  .action(async (styleId) => {
+  .option('--slides-dir <path>', 'Optional slides workspace used for style-config.json')
+  .action(async (styleId, options = {}) => {
     try {
       const { requireDesignStyle } = await import('../src/design-styles.js');
       const {
         getStyleConfigPath,
         writeSelectedStyleConfig,
       } = await import('../src/style-config.js');
+      const workspaceDir = resolveWorkspaceDir(options.slidesDir);
       const style = requireDesignStyle(String(styleId));
 
-      await writeSelectedStyleConfig({ cwd: process.cwd(), style });
+      await writeSelectedStyleConfig({ cwd: workspaceDir, style });
 
       console.log(`Selected style: ${style.title} (${style.id})`);
-      console.log(`Saved selection to ${getStyleConfigPath(process.cwd())}`);
-      console.log(`Preview anytime with: slides-grab preview-styles --style ${style.id}`);
+      console.log(`Saved selection to ${getStyleConfigPath(workspaceDir)}`);
+      console.log(`Preview anytime with: slides-grab preview-styles --style ${style.id}${buildSlidesDirSuffix(options.slidesDir)}`);
     } catch (error) {
       reportCliError(error);
     }

--- a/bin/ppt-agent.js
+++ b/bin/ppt-agent.js
@@ -2,7 +2,7 @@
 
 import { spawn } from 'node:child_process';
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
+import { dirname, isAbsolute, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Command } from 'commander';
 import {
@@ -82,6 +82,16 @@ function resolveWorkspaceDir(slidesDir) {
 
 function buildSlidesDirSuffix(slidesDir) {
   return slidesDir ? ` --slides-dir ${slidesDir}` : '';
+}
+
+function resolvePreviewOutputPath(output, workspaceDir, explicitOutput) {
+  if (isAbsolute(output)) {
+    return output;
+  }
+  if (!explicitOutput && output === 'style-preview.html') {
+    return resolve(workspaceDir, output);
+  }
+  return resolve(process.cwd(), output);
 }
 
 function formatInvalidStyleSelectionMessage(config) {
@@ -335,12 +345,13 @@ program
   .option('--slides-dir <path>', 'Optional slides workspace used for style-config.json and default preview output')
   .option('--style <id>', 'Focus the preview on a single style id')
   .option('--output <path>', 'Output HTML path', 'style-preview.html')
-  .action(async (options = {}) => {
+  .action(async (options = {}, command) => {
     try {
       const { buildStylePreviewHtml, requireDesignStyle } = await import('../src/design-styles.js');
       const { readSelectedStyleConfig } = await import('../src/style-config.js');
       const workspaceDir = resolveWorkspaceDir(options.slidesDir);
-      const outputPath = resolve(workspaceDir, options.output);
+      const explicitOutput = command?.getOptionValueSource('output') === 'cli';
+      const outputPath = resolvePreviewOutputPath(String(options.output), workspaceDir, explicitOutput);
       const currentSelection = await readSelectedStyleConfig(workspaceDir, { allowInvalidSelection: true });
       const selectedStyle = options.style ? requireDesignStyle(String(options.style)) : null;
       const html = buildStylePreviewHtml({

--- a/bin/ppt-agent.js
+++ b/bin/ppt-agent.js
@@ -80,8 +80,16 @@ function resolveWorkspaceDir(slidesDir) {
   return resolve(process.cwd(), String(slidesDir));
 }
 
+function quoteShellArg(value) {
+  const stringValue = String(value);
+  if (!/[\s"'\\$`!()[\]{}<>|&;*?]/.test(stringValue)) {
+    return stringValue;
+  }
+  return `'${stringValue.replaceAll('\'', `'\\''`)}'`;
+}
+
 function buildSlidesDirSuffix(slidesDir) {
-  return slidesDir ? ` --slides-dir ${slidesDir}` : '';
+  return slidesDir ? ` --slides-dir ${quoteShellArg(slidesDir)}` : '';
 }
 
 function resolvePreviewOutputPath(output, workspaceDir, explicitOutput) {

--- a/bin/ppt-agent.js
+++ b/bin/ppt-agent.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { spawn } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Command } from 'commander';
@@ -66,6 +66,11 @@ async function runCommand(relativePath, args = []) {
 
 function collectRepeatedOption(value, previous = []) {
   return [...previous, value];
+}
+
+function reportCliError(error) {
+  console.error(`[slides-grab] ${error.message}`);
+  process.exitCode = 1;
 }
 
 const program = new Command();
@@ -260,6 +265,95 @@ program
       console.log(`  ${t.name.padEnd(20)} ${tag}`);
     }
     console.log(`\nTotal: ${themes.length} themes`);
+  });
+
+program
+  .command('list-styles')
+  .description('List bundled design collections users can preview/select before slide generation')
+  .action(async () => {
+    try {
+      const [{ listDesignStyles }, { readSelectedStyleConfig }] = await Promise.all([
+        import('../src/design-styles.js'),
+        import('../src/style-config.js'),
+      ]);
+      const styles = listDesignStyles();
+      const selectedConfig = await readSelectedStyleConfig(process.cwd());
+      const selectedStyleId = selectedConfig?.style?.id ?? null;
+
+      if (styles.length === 0) {
+        console.log('No bundled design styles found.');
+        return;
+      }
+
+      console.log('Available design styles:\n');
+      for (const style of styles) {
+        const selectedTag = style.id === selectedStyleId ? '  [selected]' : '';
+        console.log(`  ${style.id.padEnd(22)} ${style.title}${selectedTag}`);
+        console.log(`    ${style.mood} · ${style.bestFor}`);
+      }
+
+      console.log(`\nTotal: ${styles.length} styles`);
+      if (selectedConfig?.style) {
+        console.log(`Selected style: ${selectedConfig.style.title} (${selectedConfig.style.id})`);
+      } else {
+        console.log('Selected style: none');
+      }
+    } catch (error) {
+      reportCliError(error);
+    }
+  });
+
+program
+  .command('preview-styles')
+  .description('Generate a local HTML preview for the full design catalog or one selected style')
+  .option('--style <id>', 'Focus the preview on a single style id')
+  .option('--output <path>', 'Output HTML path', 'style-preview.html')
+  .action(async (options = {}) => {
+    try {
+      const { buildStylePreviewHtml, requireDesignStyle } = await import('../src/design-styles.js');
+      const { readSelectedStyleConfig } = await import('../src/style-config.js');
+      const outputPath = resolve(process.cwd(), options.output);
+      const currentSelection = await readSelectedStyleConfig(process.cwd());
+      const selectedStyle = options.style ? requireDesignStyle(String(options.style)) : null;
+      const html = buildStylePreviewHtml({
+        styleId: selectedStyle?.id,
+        selectedStyleId: selectedStyle?.id ?? currentSelection?.selectedStyleId ?? null,
+      });
+
+      mkdirSync(dirname(outputPath), { recursive: true });
+      writeFileSync(outputPath, html, 'utf-8');
+
+      if (selectedStyle) {
+        console.log(`Wrote style preview for ${selectedStyle.title} to ${outputPath}`);
+      } else {
+        console.log(`Wrote style preview catalog to ${outputPath}`);
+      }
+    } catch (error) {
+      reportCliError(error);
+    }
+  });
+
+program
+  .command('select-style')
+  .description('Persist a selected bundled design style before slide generation')
+  .argument('<id>', 'Design style id (e.g. "glassmorphism")')
+  .action(async (styleId) => {
+    try {
+      const { requireDesignStyle } = await import('../src/design-styles.js');
+      const {
+        getStyleConfigPath,
+        writeSelectedStyleConfig,
+      } = await import('../src/style-config.js');
+      const style = requireDesignStyle(String(styleId));
+
+      await writeSelectedStyleConfig({ cwd: process.cwd(), style });
+
+      console.log(`Selected style: ${style.title} (${style.id})`);
+      console.log(`Saved selection to ${getStyleConfigPath(process.cwd())}`);
+      console.log(`Preview anytime with: slides-grab preview-styles --style ${style.id}`);
+    } catch (error) {
+      reportCliError(error);
+    }
   });
 
 program

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "build-viewer": "node scripts/build-viewer.js",
     "validate": "node scripts/validate-slides.js",
     "convert": "node convert.cjs",
-    "test": "node --test --test-concurrency=1 tests/editor/editor-codex-edit.test.js tests/editor/editor-server.test.js tests/nano-banana/nano-banana.test.js tests/pdf/html2pdf.test.js tests/pdf/html2pdf.e2e.test.js tests/figma/figma-export.test.js tests/image-contract/image-contract.test.js tests/tldraw/render-tldraw.test.js tests/validation/validate-slides.test.js tests/skills/installable-skills.test.js tests/video/download-video.test.js",
+    "test": "node --test --test-concurrency=1 tests/design/design-styles.test.js tests/editor/editor-codex-edit.test.js tests/editor/editor-server.test.js tests/nano-banana/nano-banana.test.js tests/pdf/html2pdf.test.js tests/pdf/html2pdf.e2e.test.js tests/figma/figma-export.test.js tests/image-contract/image-contract.test.js tests/tldraw/render-tldraw.test.js tests/validation/validate-slides.test.js tests/skills/installable-skills.test.js tests/video/download-video.test.js",
     "test:e2e": "node --test tests/editor/editor-ui.e2e.test.js tests/editor/editor-concurrency.e2e.test.js"
   },
   "dependencies": {

--- a/skills/slides-grab-design/SKILL.md
+++ b/skills/slides-grab-design/SKILL.md
@@ -14,6 +14,7 @@ Generate high-quality `slide-XX.html` files in the selected slides workspace (`s
 
 ## Inputs
 - Approved `slide-outline.md`
+- Optional approved `style-config.json`
 - Theme/layout preferences
 - Requested edits per slide
 
@@ -23,19 +24,20 @@ Generate high-quality `slide-XX.html` files in the selected slides workspace (`s
 
 ## Workflow
 1. Read approved `slide-outline.md`.
-2. Before generating slides, write a quick **visual thesis** (mood/material/energy), a **content plan** (opener → support/proof → detail/story → close/CTA), and the core design tokens (background, surface, text, muted, accent + display/headline/body/caption roles).
-3. Generate slide HTML files with 2-digit numbering in selected `--slides-dir`.
-4. When a slide explicitly needs bespoke imagery, when the user asks for an image, or when stronger imagery would materially improve the slide, prefer `slides-grab image --prompt "<prompt>" --slides-dir <path>` to generate a local asset with Nano Banana Pro and save it under `<slides-dir>/assets/`.
-5. If the deck needs a complex diagram (architecture, workflows, relationship maps, multi-node concepts), create the diagram in `tldraw`, export it with `slides-grab tldraw`, and treat the result as a local slide asset under `<slides-dir>/assets/`.
-6. If the slide needs a local video, store the video under `<slides-dir>/assets/`, reference it as `./assets/<file>`, and prefer a `poster="./assets/<file>"` thumbnail so PDF export uses a stable still image.
-7. If the source video starts on YouTube or another supported page, use `slides-grab fetch-video --url <youtube-url> --slides-dir <path>` (or `yt-dlp` directly if needed) to download it into `<slides-dir>/assets/` before saving the slide HTML.
-8. Run `slides-grab validate --slides-dir <path>` after generation or edits.
-9. If validation fails, automatically fix the source slide HTML/CSS and re-run validation until it passes.
-10. Run the slide litmus check from `references/beautiful-slide-defaults.md` before presenting the deck for review.
-11. Launch the interactive editor for visual review: `slides-grab edit --slides-dir <path>`
-12. Iterate on user feedback by editing only requested slide files, then re-run validation after each edit round.
-13. When the user confirms editing is complete, suggest: build the viewer (`slides-grab build-viewer --slides-dir <path>`) for a final read-only preview, or proceed to export (PDF/PPTX).
-14. Keep revising until user approves conversion stage.
+2. If `style-config.json` exists, read it before deciding the visual direction. When the design direction is still open, suggest `slides-grab list-styles`, optionally `slides-grab preview-styles --style <id>`, and confirm the user-approved style before generation.
+3. Before generating slides, write a quick **visual thesis** (mood/material/energy), a **content plan** (opener → support/proof → detail/story → close/CTA), and the core design tokens (background, surface, text, muted, accent + display/headline/body/caption roles).
+4. Generate slide HTML files with 2-digit numbering in selected `--slides-dir`.
+5. When a slide explicitly needs bespoke imagery, when the user asks for an image, or when stronger imagery would materially improve the slide, prefer `slides-grab image --prompt "<prompt>" --slides-dir <path>` to generate a local asset with Nano Banana Pro and save it under `<slides-dir>/assets/`.
+6. If the deck needs a complex diagram (architecture, workflows, relationship maps, multi-node concepts), create the diagram in `tldraw`, export it with `slides-grab tldraw`, and treat the result as a local slide asset under `<slides-dir>/assets/`.
+7. If the slide needs a local video, store the video under `<slides-dir>/assets/`, reference it as `./assets/<file>`, and prefer a `poster="./assets/<file>"` thumbnail so PDF export uses a stable still image.
+8. If the source video starts on YouTube or another supported page, use `slides-grab fetch-video --url <youtube-url> --slides-dir <path>` (or `yt-dlp` directly if needed) to download it into `<slides-dir>/assets/` before saving the slide HTML.
+9. Run `slides-grab validate --slides-dir <path>` after generation or edits.
+10. If validation fails, automatically fix the source slide HTML/CSS and re-run validation until it passes.
+11. Run the slide litmus check from `references/beautiful-slide-defaults.md` before presenting the deck for review.
+12. Launch the interactive editor for visual review: `slides-grab edit --slides-dir <path>`
+13. Iterate on user feedback by editing only requested slide files, then re-run validation after each edit round.
+14. When the user confirms editing is complete, suggest: build the viewer (`slides-grab build-viewer --slides-dir <path>`) for a final read-only preview, or proceed to export (PDF/PPTX).
+15. Keep revising until user approves conversion stage.
 
 ## Rules
 - Keep slide size 720pt x 405pt.

--- a/skills/slides-grab-design/references/design-rules.md
+++ b/skills/slides-grab-design/references/design-rules.md
@@ -9,6 +9,9 @@ These are the packaged design rules for installable `slides-grab` skills.
 - Generate a bespoke image asset: `slides-grab image --prompt "<prompt>" --slides-dir <path>`
 - Download a web video into slide assets: `slides-grab fetch-video --url <youtube-url> --slides-dir <path>`
 - Render `tldraw` diagrams: `slides-grab tldraw --input <path> --output <path>`
+- List bundled design collections: `slides-grab list-styles`
+- Preview the full style catalog or one style: `slides-grab preview-styles [--style <id>]`
+- Persist the approved style direction: `slides-grab select-style <id>`
 
 ## Slide spec
 - Slide size: `720pt x 405pt` (16:9)
@@ -52,8 +55,10 @@ These are the packaged design rules for installable `slides-grab` skills.
 - `templates/diagram.html`
 - `templates/diagram-tldraw.html`
 - `templates/custom/`
+- `templates/design-styles/README.md` — bundled design collection reference derived from `corazzon/pptx-design-styles`
 
 ## Review loop
+- If the design direction is still open, shortlist bundled styles first and persist the approved direction in `style-config.json` before generating slides.
 - Generate or edit only the needed slide files.
 - Prefer `slides-grab image` before remote image sourcing when the slide needs bespoke imagery.
 - Prefer `tldraw` for complex diagrams instead of hand-building dense diagram geometry in HTML/CSS.

--- a/skills/slides-grab/SKILL.md
+++ b/skills/slides-grab/SKILL.md
@@ -29,7 +29,7 @@ Use the installed **slides-grab-plan** skill.
 Use the installed **slides-grab-design** skill.
 
 1. Read approved `slide-outline.md`.
-2. If the design direction is still open, shortlist bundled design collections with `slides-grab list-styles`, preview one or the full catalog with `slides-grab preview-styles`, and persist the approved direction with `slides-grab select-style <id>` before generating slides.
+2. If the design direction is still open, shortlist bundled design collections with `slides-grab list-styles`, preview one or the full catalog with `slides-grab preview-styles`, and persist the approved direction with `slides-grab select-style <id>` before generating slides. For multi-deck projects, append `--slides-dir <path>` so the deck-local `style-config.json` stays with that workspace.
 3. Generate `slide-*.html` files in the slides workspace (default: `slides/`).
 4. Run validation: `slides-grab validate --slides-dir <path>`
 5. If validation fails, automatically fix the slide HTML/CSS until validation passes.

--- a/skills/slides-grab/SKILL.md
+++ b/skills/slides-grab/SKILL.md
@@ -29,16 +29,17 @@ Use the installed **slides-grab-plan** skill.
 Use the installed **slides-grab-design** skill.
 
 1. Read approved `slide-outline.md`.
-2. Generate `slide-*.html` files in the slides workspace (default: `slides/`).
-3. Run validation: `slides-grab validate --slides-dir <path>`
-4. If validation fails, automatically fix the slide HTML/CSS until validation passes.
-5. For bespoke slide imagery, use `slides-grab image --prompt "<prompt>" --slides-dir <path>` so Nano Banana Pro saves a local asset under `<slides-dir>/assets/`.
-6. For complex diagrams (architecture, workflows, relationship maps, multi-node concepts), prefer `tldraw` over hand-built HTML/CSS diagrams. Render the asset with `slides-grab tldraw`, store it under `<slides-dir>/assets/`, and place it in the slide with a normal `<img>`.
-7. Keep local videos under `<slides-dir>/assets/`, prefer `poster="./assets/<file>"` thumbnails, and use `slides-grab fetch-video --url <youtube-url> --slides-dir <path>` (or `yt-dlp` directly) when the source starts on a supported web page.
-8. If `GOOGLE_API_KEY` (or `GEMINI_API_KEY`) is unavailable or Nano Banana is down, ask the user for a Google API key or fall back to web search/download into `<slides-dir>/assets/`.
-9. Launch the interactive editor for review: `slides-grab edit --slides-dir <path>`
-10. Revise slides based on user feedback via the editor, then re-run validation after each edit round.
-11. When the user confirms editing is complete, suggest next steps: build the viewer (`slides-grab build-viewer --slides-dir <path>`) for a final preview, or proceed directly to Stage 3 for PDF/PPTX export.
+2. If the design direction is still open, shortlist bundled design collections with `slides-grab list-styles`, preview one or the full catalog with `slides-grab preview-styles`, and persist the approved direction with `slides-grab select-style <id>` before generating slides.
+3. Generate `slide-*.html` files in the slides workspace (default: `slides/`).
+4. Run validation: `slides-grab validate --slides-dir <path>`
+5. If validation fails, automatically fix the slide HTML/CSS until validation passes.
+6. For bespoke slide imagery, use `slides-grab image --prompt "<prompt>" --slides-dir <path>` so Nano Banana Pro saves a local asset under `<slides-dir>/assets/`.
+7. For complex diagrams (architecture, workflows, relationship maps, multi-node concepts), prefer `tldraw` over hand-built HTML/CSS diagrams. Render the asset with `slides-grab tldraw`, store it under `<slides-dir>/assets/`, and place it in the slide with a normal `<img>`.
+8. Keep local videos under `<slides-dir>/assets/`, prefer `poster="./assets/<file>"` thumbnails, and use `slides-grab fetch-video --url <youtube-url> --slides-dir <path>` (or `yt-dlp` directly) when the source starts on a supported web page.
+9. If `GOOGLE_API_KEY` (or `GEMINI_API_KEY`) is unavailable or Nano Banana is down, ask the user for a Google API key or fall back to web search/download into `<slides-dir>/assets/`.
+10. Launch the interactive editor for review: `slides-grab edit --slides-dir <path>`
+11. Revise slides based on user feedback via the editor, then re-run validation after each edit round.
+12. When the user confirms editing is complete, suggest next steps: build the viewer (`slides-grab build-viewer --slides-dir <path>`) for a final preview, or proceed directly to Stage 3 for PDF/PPTX export.
 
 **Do not proceed to Stage 3 without approval.**
 

--- a/skills/slides-grab/references/presentation-workflow-reference.md
+++ b/skills/slides-grab/references/presentation-workflow-reference.md
@@ -22,7 +22,7 @@ Use the installed **slides-grab-plan** skill.
 Use the installed **slides-grab-design** skill.
 
 1. Read approved `slide-outline.md`.
-2. If the user has not approved a visual direction yet, use `slides-grab list-styles` to shortlist bundled design collections, `slides-grab preview-styles` for a local HTML gallery, and `slides-grab select-style <id>` to persist the approved direction before generation.
+2. If the user has not approved a visual direction yet, use `slides-grab list-styles` to shortlist bundled design collections, `slides-grab preview-styles` for a local HTML gallery, and `slides-grab select-style <id>` to persist the approved direction before generation. For multi-deck projects, add `--slides-dir <path>` so the deck-local `style-config.json` stays inside that workspace.
 3. Generate `slide-*.html` files in the slides workspace (default: `slides/`).
 4. Run validation: `slides-grab validate --slides-dir <path>`
 5. If validation fails, automatically fix the slide HTML/CSS until validation passes.

--- a/skills/slides-grab/references/presentation-workflow-reference.md
+++ b/skills/slides-grab/references/presentation-workflow-reference.md
@@ -22,17 +22,18 @@ Use the installed **slides-grab-plan** skill.
 Use the installed **slides-grab-design** skill.
 
 1. Read approved `slide-outline.md`.
-2. Generate `slide-*.html` files in the slides workspace (default: `slides/`).
-3. Run validation: `slides-grab validate --slides-dir <path>`
-4. If validation fails, automatically fix the slide HTML/CSS until validation passes.
-5. Build the viewer: `slides-grab build-viewer --slides-dir <path>`
-6. When a slide calls for bespoke imagery, prefer `slides-grab image --prompt "<prompt>" --slides-dir <path>` so Nano Banana Pro saves a local asset under `<slides-dir>/assets/`.
-7. For complex diagrams (architecture, workflows, relationship maps, multi-node concepts), prefer `tldraw`. Render a local diagram asset with `slides-grab tldraw`, store it under `<slides-dir>/assets/`, and place it into the slide with a normal `<img>`.
-8. Keep local videos under `<slides-dir>/assets/`, prefer `poster="./assets/<file>"` thumbnails, and use `slides-grab fetch-video --url <youtube-url> --slides-dir <path>` (or `yt-dlp` directly) when the source starts on a supported web page.
-9. If `GOOGLE_API_KEY` or `GEMINI_API_KEY` is unavailable, or the Nano Banana API fails, ask the user for a Google API key or fall back to web search + download into `<slides-dir>/assets/`.
-10. Present viewer to user for review.
-11. Revise individual slides based on feedback, then re-run validation and rebuild the viewer.
-12. Optionally launch the visual editor: `slides-grab edit --slides-dir <path>`
+2. If the user has not approved a visual direction yet, use `slides-grab list-styles` to shortlist bundled design collections, `slides-grab preview-styles` for a local HTML gallery, and `slides-grab select-style <id>` to persist the approved direction before generation.
+3. Generate `slide-*.html` files in the slides workspace (default: `slides/`).
+4. Run validation: `slides-grab validate --slides-dir <path>`
+5. If validation fails, automatically fix the slide HTML/CSS until validation passes.
+6. Build the viewer: `slides-grab build-viewer --slides-dir <path>`
+7. When a slide calls for bespoke imagery, prefer `slides-grab image --prompt "<prompt>" --slides-dir <path>` so Nano Banana Pro saves a local asset under `<slides-dir>/assets/`.
+8. For complex diagrams (architecture, workflows, relationship maps, multi-node concepts), prefer `tldraw`. Render a local diagram asset with `slides-grab tldraw`, store it under `<slides-dir>/assets/`, and place it into the slide with a normal `<img>`.
+9. Keep local videos under `<slides-dir>/assets/`, prefer `poster="./assets/<file>"` thumbnails, and use `slides-grab fetch-video --url <youtube-url> --slides-dir <path>` (or `yt-dlp` directly) when the source starts on a supported web page.
+10. If `GOOGLE_API_KEY` or `GEMINI_API_KEY` is unavailable, or the Nano Banana API fails, ask the user for a Google API key or fall back to web search + download into `<slides-dir>/assets/`.
+11. Present viewer to user for review.
+12. Revise individual slides based on feedback, then re-run validation and rebuild the viewer.
+13. Optionally launch the visual editor: `slides-grab edit --slides-dir <path>`
 
 **Do not proceed to Stage 3 without approval.**
 

--- a/src/design-styles-data.js
+++ b/src/design-styles-data.js
@@ -1,0 +1,1606 @@
+/**
+ * Derived from corazzon/pptx-design-styles (MIT).
+ * Source references: README.md, references/styles.md, and
+ * preview/modern-pptx-designs-30.html in the upstream repository.
+ */
+
+export const RAW_DESIGN_STYLES = [
+  {
+    "number": "01",
+    "title": "Glassmorphism",
+    "mood": "Premium · Tech",
+    "bestFor": "SaaS, AI",
+    "id": "glassmorphism",
+    "background": [
+      "Deep 3-color gradient: `#1A1A4E → #6B21A8 → #1E3A5F`",
+      "Or deep single-tone blue: `#0F0F2D`"
+    ],
+    "colors": [
+      {
+        "role": "Title text",
+        "label": "White",
+        "hex": "#FFFFFF"
+      },
+      {
+        "role": "Body text",
+        "label": "Soft white",
+        "hex": "#E0E0F0"
+      }
+    ],
+    "fonts": [
+      "Title: **Segoe UI Light / Calibri Light**, 36–44pt, bold",
+      "Body: **Segoe UI**, 14–16pt, regular",
+      "KPI numbers: 52–64pt bold"
+    ],
+    "layout": [
+      "**Card-based**: use frosted-glass rectangles as content containers",
+      "Rounded corners (radius 12–20px equivalent)",
+      "Layer cards slightly offset and rotated ±5° for depth",
+      "Add large blurred circles/ellipses behind cards for glow effect"
+    ],
+    "signature": [
+      "Translucent card (fill 15–20%, white border 25%)",
+      "Blurred glow blobs in background",
+      "All containers use the same glass treatment"
+    ],
+    "avoid": [
+      "White backgrounds (kills the effect)",
+      "Fully opaque cards",
+      "Bright saturated solid colors"
+    ]
+  },
+  {
+    "number": "02",
+    "title": "Neo-Brutalism",
+    "mood": "Bold · Startup",
+    "bestFor": "Pitch decks",
+    "id": "neo-brutalism",
+    "background": [
+      "High-saturation solid: Yellow `#F5F500`, Lime `#CCFF00`, Hot pink `#FF2D55`",
+      "Or pure white `#FFFFFF`"
+    ],
+    "colors": [
+      {
+        "role": "Border & shadow",
+        "label": "Pure black",
+        "hex": "#000000"
+      },
+      {
+        "role": "Text",
+        "label": "Black",
+        "hex": "#000000"
+      }
+    ],
+    "fonts": [
+      "Title: **Arial Black / Impact / Bebas Neue**, 40–56pt",
+      "Body: **Courier New / Space Mono**, 13–16pt",
+      "Numbers: 72–96pt Arial Black"
+    ],
+    "layout": [
+      "**Thick black borders** on all elements (2–4pt solid black)",
+      "**Hard offset shadow** bottom-right of every card (5–8pt, no blur)",
+      "Slight intentional misalignment — tilted shapes allowed"
+    ],
+    "signature": [
+      "Hard drop shadow (no blur, pure black offset)",
+      "Thick border on every element",
+      "One oversized number or word breaking the layout"
+    ],
+    "avoid": [
+      "Soft shadows or gradients",
+      "Rounded corners",
+      "Pastel or muted colors"
+    ]
+  },
+  {
+    "number": "03",
+    "title": "Bento Grid",
+    "mood": "Modular · Structured",
+    "bestFor": "Product features",
+    "id": "bento-grid",
+    "background": [
+      "Near-white: `#F8F8F2` or `#F0F0F0`"
+    ],
+    "colors": [
+      {
+        "role": "Background",
+        "label": "Off-white",
+        "hex": "#F8F8F2"
+      },
+      {
+        "role": "Cell 1 (dark)",
+        "label": "Deep navy",
+        "hex": "#1A1A2E"
+      },
+      {
+        "role": "Cell 2 (accent 1)",
+        "label": "Bright yellow",
+        "hex": "#E8FF3B"
+      },
+      {
+        "role": "Cell 3 (accent 2)",
+        "label": "Coral red",
+        "hex": "#FF6B6B"
+      },
+      {
+        "role": "Cell 4 (accent 3)",
+        "label": "Teal",
+        "hex": "#4ECDC4"
+      },
+      {
+        "role": "Cell 5 (warm)",
+        "label": "Warm yellow",
+        "hex": "#FFE66D"
+      }
+    ],
+    "fonts": [
+      "Cell title: **SF Pro / Inter**, 18–24pt, semibold",
+      "Cell body: **Inter**, 12–14pt, regular",
+      "Large stat: 48–64pt bold in dark cell"
+    ],
+    "layout": [
+      "CSS Grid-style layout: cells of different sizes spanning columns/rows",
+      "Gap between cells: 8–12pt equivalent",
+      "**Asymmetric merging**: one cell spans 2 columns, one spans 2 rows",
+      "Each cell has one focused piece of info"
+    ],
+    "signature": [
+      "Asymmetric multi-size grid",
+      "One dark anchor cell with white text",
+      "Color-coded cells for visual hierarchy"
+    ],
+    "avoid": [
+      "Equal-sized cells (boring)",
+      "Too many colors (max 5)",
+      "Dense text inside cells"
+    ]
+  },
+  {
+    "number": "04",
+    "title": "Dark Academia",
+    "mood": "Scholarly · Refined",
+    "bestFor": "Education, research",
+    "id": "dark-academia",
+    "background": [
+      "Deep warm dark brown: `#1A1208`",
+      "Or `#0E0A05` for maximum drama"
+    ],
+    "colors": [
+      {
+        "role": "Background",
+        "label": "Deep warm brown",
+        "hex": "#1A1208"
+      },
+      {
+        "role": "Title text",
+        "label": "Antique gold",
+        "hex": "#C9A84C"
+      },
+      {
+        "role": "Body text",
+        "label": "Warm parchment",
+        "hex": "#D4BF9A"
+      },
+      {
+        "role": "Border / ornament",
+        "label": "Dark gold",
+        "hex": "#3D2E10"
+      },
+      {
+        "role": "Accent",
+        "label": "Muted gold",
+        "hex": "#8A7340"
+      }
+    ],
+    "fonts": [
+      "Title: **Playfair Display Italic / Georgia Italic**, 36–48pt",
+      "Body: **EB Garamond / Georgia**, 13–16pt",
+      "Label: **Space Mono**, 9–11pt, wide letter-spacing"
+    ],
+    "layout": [
+      "**Inset border frame** — thin gold border 12–20pt from slide edge",
+      "Centered title with wide letter-spacing (6–10pt)",
+      "Body text in serif, generous leading (1.6–1.8)",
+      "Decorative horizontal rule line (thin, gold tint)"
+    ],
+    "signature": [
+      "Double inset border (outer + inner, slightly different widths)",
+      "Italic serif title in gold",
+      "Monospace footnote or date in muted gold"
+    ],
+    "avoid": [
+      "Modern sans-serif fonts",
+      "Bright or saturated colors",
+      "Clean minimal layouts — add texture and decoration"
+    ]
+  },
+  {
+    "number": "05",
+    "title": "Gradient Mesh",
+    "mood": "Artistic · Vibrant",
+    "bestFor": "Brand launches",
+    "id": "gradient-mesh",
+    "background": [
+      "Multi-point radial gradient blend (4–6 colors overlapping)",
+      "Example: `#FF6EC7` + `#7B61FF` + `#00D4FF` + `#FFB347` bleeding into each other"
+    ],
+    "colors": [
+      {
+        "role": "Mesh node 1",
+        "label": "Hot pink",
+        "hex": "#FF6EC7"
+      },
+      {
+        "role": "Mesh node 2",
+        "label": "Violet",
+        "hex": "#7B61FF"
+      },
+      {
+        "role": "Mesh node 3",
+        "label": "Cyan",
+        "hex": "#00D4FF"
+      },
+      {
+        "role": "Mesh node 4",
+        "label": "Warm orange",
+        "hex": "#FFB347"
+      },
+      {
+        "role": "Text",
+        "label": "Pure white",
+        "hex": "#FFFFFF"
+      }
+    ],
+    "fonts": [
+      "Title: **Bebas Neue / Barlow Condensed ExtraBold**, 48–72pt",
+      "Body: **Outfit / Poppins Light**, 14–16pt",
+      "All text white with subtle drop shadow for legibility"
+    ],
+    "layout": [
+      "Full-bleed gradient as background",
+      "Minimal text overlay — let the gradient breathe",
+      "Large centered title, small subtitle below",
+      "Optional: frosted glass card for body text"
+    ],
+    "signature": [
+      "Multi-radial gradient that feels painterly, not linear",
+      "White text with drop shadow",
+      "Large typographic element dominating"
+    ],
+    "avoid": [
+      "Linear two-color gradients (too plain)",
+      "Dark or muted text",
+      "Overcrowded layouts"
+    ]
+  },
+  {
+    "number": "06",
+    "title": "Claymorphism",
+    "mood": "Friendly · 3D",
+    "bestFor": "Apps, education",
+    "id": "claymorphism",
+    "background": [
+      "Warm pastel gradient: `#FFECD2 → #FCB69F` or `#E0F7FA → #B2EBF2`"
+    ],
+    "colors": [
+      {
+        "role": "Clay element 1",
+        "label": "Soft teal",
+        "hex": "#A8EDEA"
+      },
+      {
+        "role": "Clay element 2",
+        "label": "Blush pink",
+        "hex": "#FED6E3"
+      },
+      {
+        "role": "Clay element 3",
+        "label": "Warm yellow",
+        "hex": "#FFEAA7"
+      }
+    ],
+    "fonts": [
+      "Title: **Nunito ExtraBold / Rounded Mplus**, 32–48pt",
+      "Body: **Nunito / DM Sans**, 14–16pt",
+      "Icon labels: 11–13pt medium"
+    ],
+    "layout": [
+      "**3D rounded shapes** as primary containers (radius 20–32pt equivalent)",
+      "Each element casts a **colored drop shadow** (same hue, shifted down, no X offset)",
+      "Inner highlight on top edge (white, 30% opacity)",
+      "Playful asymmetric arrangement of clay bubbles"
+    ],
+    "signature": [
+      "Colored soft shadow (not grey) matching element color",
+      "Very high border radius",
+      "Inner highlight stripe at top of each element"
+    ],
+    "avoid": [
+      "Sharp corners",
+      "Grey/neutral shadows",
+      "Flat design elements mixed in"
+    ]
+  },
+  {
+    "number": "07",
+    "title": "Swiss International Style",
+    "mood": "Functional · Corporate",
+    "bestFor": "Consulting, finance",
+    "id": "swiss-international-style",
+    "background": [
+      "Pure white: `#FFFFFF`",
+      "Or off-white: `#FAFAFA`"
+    ],
+    "colors": [
+      {
+        "role": "Background",
+        "label": "White",
+        "hex": "#FFFFFF"
+      },
+      {
+        "role": "Primary text",
+        "label": "Near-black",
+        "hex": "#111111"
+      },
+      {
+        "role": "Accent bar",
+        "label": "Signal red",
+        "hex": "#E8000D"
+      },
+      {
+        "role": "Secondary text",
+        "label": "Dark grey",
+        "hex": "#444444"
+      },
+      {
+        "role": "Divider line",
+        "label": "Light grey",
+        "hex": "#DDDDDD"
+      }
+    ],
+    "fonts": [
+      "Title: **Helvetica Neue Bold / Arial Bold**, 32–44pt, tight leading",
+      "Body: **Helvetica Neue / Arial**, 12–14pt",
+      "Labels/captions: **Space Mono**, 9–10pt, 3–4pt letter-spacing"
+    ],
+    "layout": [
+      "Strict **5-column or 12-column grid** — every element snaps to columns",
+      "**Vertical red rule** on left edge (4–8pt wide stripe)",
+      "Single horizontal divider rule at mid-slide",
+      "Circle accent element (red outline) in lower-right zone"
+    ],
+    "signature": [
+      "Left-edge vertical red bar",
+      "Horizontal rule dividing title from content",
+      "Grid-aligned text blocks with generous margins"
+    ],
+    "avoid": [
+      "Decorative or illustrative elements",
+      "Rounded corners",
+      "More than 2 fonts"
+    ]
+  },
+  {
+    "number": "08",
+    "title": "Aurora Neon Glow",
+    "mood": "Futuristic · AI",
+    "bestFor": "AI, cybersecurity",
+    "id": "aurora-neon-glow",
+    "background": [
+      "Near-black deep space: `#050510` or `#020208`"
+    ],
+    "colors": [
+      {
+        "role": "Background",
+        "label": "Deep space black",
+        "hex": "#050510"
+      },
+      {
+        "role": "Glow 1",
+        "label": "Neon green",
+        "hex": "#00FF88"
+      },
+      {
+        "role": "Glow 2",
+        "label": "Electric violet",
+        "hex": "#7B00FF"
+      },
+      {
+        "role": "Glow 3",
+        "label": "Cyan",
+        "hex": "#00B4FF"
+      },
+      {
+        "role": "Body text",
+        "label": "Soft white",
+        "hex": "#D0D0F0"
+      }
+    ],
+    "fonts": [
+      "Title: **Bebas Neue / Barlow Condensed**, 44–60pt, wide letter-spacing 4–8pt",
+      "Body: **DM Mono / Space Mono**, 12–14pt",
+      "Gradient text clip on title"
+    ],
+    "layout": [
+      "Large blurred glow blobs (filter blur 30–50pt) in background corners",
+      "Centered or left-aligned title with gradient text effect",
+      "Body on semi-transparent dark panel",
+      "Optional scan-line texture overlay (5% opacity)"
+    ],
+    "signature": [
+      "Blurred neon glow circles (not sharp shapes)",
+      "Gradient text (green → cyan → violet)",
+      "Dark panel for body text legibility"
+    ],
+    "avoid": [
+      "White or light backgrounds",
+      "Solid non-glowing colors",
+      "Dense body text without panels"
+    ]
+  },
+  {
+    "number": "09",
+    "title": "Retro Y2K",
+    "mood": "Nostalgic · Pop",
+    "bestFor": "Events, marketing",
+    "id": "retro-y2k",
+    "background": [
+      "Navy blue: `#000080`",
+      "Or electric blue: `#0020C2`"
+    ],
+    "colors": [
+      {
+        "role": "Background",
+        "label": "Navy",
+        "hex": "#000080"
+      },
+      {
+        "role": "Title text",
+        "label": "White",
+        "hex": "#FFFFFF"
+      },
+      {
+        "role": "Star accent",
+        "label": "Yellow",
+        "hex": "#FFFF00"
+      }
+    ],
+    "fonts": [
+      "Title: **Bebas Neue / Impact**, 36–52pt",
+      "Body: **VT323 / Space Mono**, 12–14pt",
+      "Double text shadow: 2px cyan + 2px magenta offset"
+    ],
+    "layout": [
+      "**Rainbow stripe bars** top and bottom (6–8pt height)",
+      "Star/sparkle icons in corners (✦ ★)",
+      "Title centered with double text shadow",
+      "Optional: spinning star animation placeholder"
+    ],
+    "signature": [
+      "Rainbow gradient stripe bars",
+      "Double-color text shadow (cyan + magenta)",
+      "Star/sparkle motifs"
+    ],
+    "avoid": [
+      "Minimalist layouts",
+      "Muted or desaturated colors",
+      "Serif fonts"
+    ]
+  },
+  {
+    "number": "10",
+    "title": "Nordic Minimalism",
+    "mood": "Calm · Natural",
+    "bestFor": "Wellness, non-profit",
+    "id": "nordic-minimalism",
+    "background": [
+      "Warm cream: `#F4F1EC` or `#F0EDE8`"
+    ],
+    "colors": [
+      {
+        "role": "Background",
+        "label": "Warm cream",
+        "hex": "#F4F1EC"
+      },
+      {
+        "role": "Organic shape",
+        "label": "Warm grey",
+        "hex": "#D9CFC4"
+      },
+      {
+        "role": "Primary text",
+        "label": "Dark warm brown",
+        "hex": "#3D3530"
+      },
+      {
+        "role": "Secondary text",
+        "label": "Taupe",
+        "hex": "#8A7A6A"
+      },
+      {
+        "role": "Accent dot",
+        "label": "Deep brown",
+        "hex": "#3D3530"
+      }
+    ],
+    "fonts": [
+      "Title: **Canela / Freight Display / DM Serif Display**, 36–52pt, light weight",
+      "Body: **Inter Light / Lato Light**, 13–15pt",
+      "Caption: **Space Mono**, 9–10pt, 4–6pt letter-spacing"
+    ],
+    "layout": [
+      "**Generous whitespace** — at least 40% of slide is empty",
+      "One organic blob shape as background texture (low opacity, grey-beige)",
+      "Minimal dot accent (3 dots in different brown tones) top-left corner",
+      "Thin horizontal rule near bottom, then caption text"
+    ],
+    "signature": [
+      "Organic blob background shape",
+      "3-dot color accent",
+      "Wide letter-spacing caption in monospace"
+    ],
+    "avoid": [
+      "Bright or saturated colors",
+      "Dense text or busy layouts",
+      "Sans-serif display fonts (use serif or editorial)"
+    ]
+  },
+  {
+    "number": "11",
+    "title": "Typographic Bold",
+    "mood": "Editorial · Impact",
+    "bestFor": "Brand statements",
+    "id": "typographic-bold",
+    "background": [
+      "Off-white linen: `#F0EDE8`",
+      "Or pure black: `#0A0A0A` (inverted version)"
+    ],
+    "colors": [
+      {
+        "role": "Background",
+        "label": "Off-white",
+        "hex": "#F0EDE8"
+      },
+      {
+        "role": "Primary type",
+        "label": "Near-black",
+        "hex": "#1A1A1A"
+      },
+      {
+        "role": "Accent word",
+        "label": "Signal red",
+        "hex": "#E63030"
+      },
+      {
+        "role": "Footnote",
+        "label": "Light grey",
+        "hex": "#AAAAAA"
+      }
+    ],
+    "fonts": [
+      "Oversized display: **Bebas Neue / Anton**, 80–120pt, tight tracking (-2pt)",
+      "Accent word: different color, same font",
+      "Body (if any): **Space Mono**, 9pt, wide spacing"
+    ],
+    "layout": [
+      "**Type fills the slide** — no illustrations or photos",
+      "2–3 lines maximum, massive scale",
+      "One word or phrase in accent color",
+      "Tiny footnote/label bottom-right in monospace"
+    ],
+    "signature": [
+      "Oversized type (80pt+) as the main visual",
+      "Single accent color word breaking the monochrome",
+      "Almost no margins — type bleeds toward edges"
+    ],
+    "avoid": [
+      "Images or icons (type IS the design)",
+      "More than 3 lines of large text",
+      "Mixing multiple font families"
+    ]
+  },
+  {
+    "number": "12",
+    "title": "Duotone / Color Split",
+    "mood": "Dramatic · Contrast",
+    "bestFor": "Strategy decks",
+    "id": "duotone-color-split",
+    "background": [
+      "Left half: vivid orange-red `#FF4500`",
+      "Right half: deep navy `#1A1A2E`"
+    ],
+    "colors": [
+      {
+        "role": "Left panel",
+        "label": "Orange-red",
+        "hex": "#FF4500"
+      },
+      {
+        "role": "Right panel",
+        "label": "Deep navy",
+        "hex": "#1A1A2E"
+      },
+      {
+        "role": "Divider",
+        "label": "White",
+        "hex": "#FFFFFF"
+      },
+      {
+        "role": "Left text",
+        "label": "White",
+        "hex": "#FFFFFF"
+      },
+      {
+        "role": "Right text",
+        "label": "Matches left panel color",
+        "hex": "#FF4500"
+      }
+    ],
+    "fonts": [
+      "Panel text: **Bebas Neue**, 40–56pt, vertical writing-mode optional",
+      "Caption: **Space Mono**, 9pt"
+    ],
+    "layout": [
+      "Strict **50/50 vertical split** with white divider line (2–4pt)",
+      "Each panel shows one concept, one word, or one data point",
+      "Text in left panel = white; text in right panel = left panel color",
+      "Optional: diagonal split instead of vertical"
+    ],
+    "signature": [
+      "Exact 50/50 split",
+      "White divider line",
+      "Cross-panel color echo (right text = left panel color)"
+    ],
+    "avoid": [
+      "Three or more color panels",
+      "Similar hues (needs strong contrast)",
+      "Busy content — one idea per panel"
+    ]
+  },
+  {
+    "number": "13",
+    "title": "Monochrome Minimal",
+    "mood": "Restrained · Luxury",
+    "bestFor": "Luxury brands",
+    "id": "monochrome-minimal",
+    "background": [
+      "Near-white: `#FAFAFA`",
+      "Or jet black: `#0A0A0A` (dark variant)"
+    ],
+    "colors": [
+      {
+        "role": "Background",
+        "label": "Near-white",
+        "hex": "#FAFAFA"
+      },
+      {
+        "role": "Heavy type",
+        "label": "Near-black",
+        "hex": "#1A1A1A"
+      },
+      {
+        "role": "Thin rule/border",
+        "label": "Light grey",
+        "hex": "#E0E0E0"
+      },
+      {
+        "role": "Medium element",
+        "label": "Mid grey",
+        "hex": "#888888"
+      },
+      {
+        "role": "Footnote",
+        "label": "Pale grey",
+        "hex": "#CCCCCC"
+      }
+    ],
+    "fonts": [
+      "Display: **Helvetica Neue Thin / Futura Light**, 24–36pt, extreme letter-spacing (8–12pt)",
+      "Body: **Helvetica Neue**, 11–13pt, 150% line height",
+      "Accent: **Space Mono**, 9pt"
+    ],
+    "layout": [
+      "Single thin circle outline centered (decorative, not functional)",
+      "Width-varying bars (120pt, 80pt, 40pt) as visual hierarchy stand-in",
+      "All elements centered or left-aligned — never right",
+      "Extreme negative space"
+    ],
+    "signature": [
+      "Thin circle outline as focal point",
+      "Descending-width bars (weight hierarchy without font changes)",
+      "Monospace caption with wide spacing"
+    ],
+    "avoid": [
+      "Any color (pure monochrome only)",
+      "Decorative illustration or pattern",
+      "Crowded layouts"
+    ]
+  },
+  {
+    "number": "14",
+    "title": "Cyberpunk Outline",
+    "mood": "HUD · Sci-Fi",
+    "bestFor": "Gaming, infra",
+    "id": "cyberpunk-outline",
+    "background": [
+      "Near-black: `#0D0D0D`"
+    ],
+    "colors": [
+      {
+        "role": "Background",
+        "label": "Near-black",
+        "hex": "#0D0D0D"
+      }
+    ],
+    "fonts": [
+      "Title: **Bebas Neue**, 44–60pt, letter-spacing 6–8pt, **outline text** (no fill, colored stroke)",
+      "Body: **Space Mono**, 9–11pt",
+      "Data labels: **Space Mono**, 8pt, wider spacing"
+    ],
+    "layout": [
+      "Subtle dot-grid or line-grid background (6% opacity)",
+      "**Corner bracket markers** (L-shaped, 20pt, neon) in all 4 corners",
+      "Title centered with outline stroke effect",
+      "Bottom subtext label"
+    ],
+    "signature": [
+      "Outline (stroke-only) text for title",
+      "Four corner bracket markers",
+      "Grid overlay background"
+    ],
+    "avoid": [
+      "White backgrounds",
+      "Filled (non-outline) title text",
+      "Bright, warm colors"
+    ]
+  },
+  {
+    "number": "15",
+    "title": "Editorial Magazine",
+    "mood": "Magazine · Story",
+    "bestFor": "Annual reviews",
+    "id": "editorial-magazine",
+    "background": [
+      "White `#FFFFFF` with dark block"
+    ],
+    "colors": [
+      {
+        "role": "Background (main)",
+        "label": "White",
+        "hex": "#FFFFFF"
+      },
+      {
+        "role": "Dark block",
+        "label": "Near-black",
+        "hex": "#1A1A1A"
+      },
+      {
+        "role": "Title",
+        "label": "Near-black",
+        "hex": "#1A1A1A"
+      },
+      {
+        "role": "Rule line",
+        "label": "Signal red",
+        "hex": "#E63030"
+      },
+      {
+        "role": "Caption",
+        "label": "Light grey",
+        "hex": "#BBBBBB"
+      }
+    ],
+    "fonts": [
+      "Title: **Playfair Display Italic**, 34–48pt",
+      "Subhead: **Space Mono**, 8–9pt, 2–3pt letter-spacing",
+      "Body: **Georgia**, 11–13pt"
+    ],
+    "layout": [
+      "**Asymmetric two-zone layout**: left 55% white with text, right 45% dark block",
+      "Large italic serif title upper-left",
+      "Thin red horizontal rule (2pt) below title, 60pt wide",
+      "Vertical label text rotated 90° in dark zone",
+      "Column-style body text bottom-left"
+    ],
+    "signature": [
+      "Asymmetric white/dark split",
+      "Short red rule line under title",
+      "Rotated vertical label text in dark zone"
+    ],
+    "avoid": [
+      "Symmetric or centered layouts",
+      "Sans-serif display fonts",
+      "Full-bleed colored backgrounds"
+    ]
+  },
+  {
+    "number": "16",
+    "title": "Pastel Soft UI",
+    "mood": "Soft · App-like",
+    "bestFor": "Healthcare, beauty",
+    "id": "pastel-soft-ui",
+    "background": [
+      "Soft tricolor gradient: `#FCE4F3 → #E8F4FF → #F0FCE4`"
+    ],
+    "colors": [
+      {
+        "role": "Dot accent 1",
+        "label": "Blush pink",
+        "hex": "#F9C6E8"
+      },
+      {
+        "role": "Dot accent 2",
+        "label": "Sky blue",
+        "hex": "#C6E8F9"
+      }
+    ],
+    "fonts": [
+      "Title: **Nunito Bold / DM Sans Medium**, 28–36pt",
+      "Body: **Nunito / DM Sans**, 13–15pt",
+      "Labels: **Inter**, 11pt"
+    ],
+    "layout": [
+      "Floating frosted-white cards on gradient background",
+      "Large circle card (pill shape) as central element",
+      "Small decorative blobs in opposite corners",
+      "Cards have soft colored box-shadows (color-matched to blobs)"
+    ],
+    "signature": [
+      "Frosted white card (70% opacity, white border)",
+      "Pastel tricolor gradient background",
+      "Soft color-matched shadows"
+    ],
+    "avoid": [
+      "Dark backgrounds",
+      "Saturated or primary colors",
+      "Hard drop shadows"
+    ]
+  },
+  {
+    "number": "17",
+    "title": "Dark Neon Miami",
+    "mood": "Synthwave · 80s",
+    "bestFor": "Entertainment",
+    "id": "dark-neon-miami",
+    "background": [
+      "Deep purple-black: `#0A0014`"
+    ],
+    "colors": [
+      {
+        "role": "Background",
+        "label": "Deep purple-black",
+        "hex": "#0A0014"
+      },
+      {
+        "role": "Sunset semicircle",
+        "label": "Orange → hot pink",
+        "hex": "#FF6B35 → #FF0080"
+      },
+      {
+        "role": "Title gradient",
+        "label": "Orange → pink → purple",
+        "hex": "#FF6B35 → #FF0080 → #9B00FF"
+      }
+    ],
+    "fonts": [
+      "Title: **Bebas Neue**, 36–52pt, letter-spacing 6–8pt",
+      "Body: **Space Mono**, 11–13pt",
+      "All text white or gradient"
+    ],
+    "layout": [
+      "**Horizon semicircle** (sunset) in lower-center third",
+      "Perspective grid lines converging toward horizon (4–6 lines)",
+      "Title positioned top-center",
+      "Palm tree or geometric accent in lower corners (optional)"
+    ],
+    "signature": [
+      "Sunset semicircle gradient shape",
+      "Converging perspective grid",
+      "Gradient text (orange → pink → purple)"
+    ],
+    "avoid": [
+      "Cool color palettes (blue/green dominant)",
+      "Daylight or bright backgrounds",
+      "Sans-serif body text"
+    ]
+  },
+  {
+    "number": "18",
+    "title": "Hand-crafted Organic",
+    "mood": "Natural · Eco",
+    "bestFor": "Eco brands",
+    "id": "hand-crafted-organic",
+    "background": [
+      "Craft paper warm off-white: `#FDF6EE`"
+    ],
+    "colors": [
+      {
+        "role": "Background",
+        "label": "Warm craft paper",
+        "hex": "#FDF6EE"
+      },
+      {
+        "role": "Dashed circle (outer)",
+        "label": "Light tan",
+        "hex": "#C8A882"
+      },
+      {
+        "role": "Solid circle (inner)",
+        "label": "Medium brown",
+        "hex": "#A87850"
+      },
+      {
+        "role": "Title text",
+        "label": "Dark warm brown",
+        "hex": "#6B4C2A"
+      }
+    ],
+    "fonts": [
+      "Title: **Playfair Display Italic / Cormorant Garamond Italic**, 22–34pt",
+      "Body: **EB Garamond**, 13–15pt",
+      "Caption: **Courier New**, 9pt"
+    ],
+    "layout": [
+      "**Nested circles**: outer dashed + inner solid, slightly off-center or rotated",
+      "Botanical emoji or line-art leaf accents in corners",
+      "Dashed horizontal rule spanning slide",
+      "Italic serif title centered within circles"
+    ],
+    "signature": [
+      "Dashed outer circle (imperfect, rotated 5–10°)",
+      "Nested solid inner circle",
+      "Botanical/leaf accent elements"
+    ],
+    "avoid": [
+      "Clean geometric shapes",
+      "Bright or synthetic colors",
+      "Sans-serif fonts"
+    ]
+  },
+  {
+    "number": "19",
+    "title": "Isometric 3D Flat",
+    "mood": "Technical · Structured",
+    "bestFor": "IT architecture",
+    "id": "isometric-3d-flat",
+    "background": [
+      "Dark navy: `#1E1E2E`"
+    ],
+    "colors": [
+      {
+        "role": "Background",
+        "label": "Dark navy",
+        "hex": "#1E1E2E"
+      },
+      {
+        "role": "Top face",
+        "label": "Mid violet",
+        "hex": "#7C6FFF"
+      },
+      {
+        "role": "Left face",
+        "label": "Dark violet",
+        "hex": "#4A3FCC"
+      },
+      {
+        "role": "Right face",
+        "label": "Medium violet",
+        "hex": "#6254E8"
+      },
+      {
+        "role": "Top face 2 (highlight)",
+        "label": "Light violet",
+        "hex": "#A594FF"
+      }
+    ],
+    "fonts": [
+      "Labels: **Space Mono**, 10–12pt, white",
+      "Title: **Bebas Neue / Barlow Condensed**, 28–40pt, white"
+    ],
+    "layout": [
+      "Isometric (30° angle) 3D block shapes — two or three stacked cubes",
+      "Blocks assembled left-center, title upper-right",
+      "Thin connecting lines or arrows between blocks (for diagrams)",
+      "All shapes share the same 3-face color system (top lighter, sides darker)"
+    ],
+    "signature": [
+      "Strict isometric angle (30°/60°)",
+      "3-face shading system (top, left, right faces)",
+      "Dark navy background contrast"
+    ],
+    "avoid": [
+      "Perspective 3D (use isometric only)",
+      "Rounded shapes",
+      "Light or white backgrounds"
+    ]
+  },
+  {
+    "number": "20",
+    "title": "Vaporwave",
+    "mood": "Dreamy · Subculture",
+    "bestFor": "Creative agencies",
+    "id": "vaporwave",
+    "background": [
+      "Dark purple gradient: `#1A0533 → #2D0057 → #570038`"
+    ],
+    "colors": [
+      {
+        "role": "Background",
+        "label": "Deep purple",
+        "hex": "#1A0533 → #570038"
+      },
+      {
+        "role": "Sun gradient",
+        "label": "Orange → pink → violet",
+        "hex": "#FF9F43 → #FF6B9D → #C44DFF"
+      }
+    ],
+    "fonts": [
+      "Ghost title: **Bebas Neue**, 38–52pt, 6pt spacing, near-invisible",
+      "Gradient text: **Bebas Neue**, 24–34pt",
+      "Body: **Space Mono**, 10pt"
+    ],
+    "layout": [
+      "**Perspective grid** in lower 60% (horizontal + vertical lines converging)",
+      "Semicircle sun top-center, sliced by 2 horizontal bars (background color)",
+      "Ghost watermark text near sun area",
+      "Gradient text at bottom"
+    ],
+    "signature": [
+      "Sliced sunset semicircle (sun with stripes)",
+      "Perspective grid floor",
+      "Ghost/watermark title text"
+    ],
+    "avoid": [
+      "Clean or corporate layouts",
+      "Muted or warm earth tones",
+      "Readable \"normal\" typography style"
+    ]
+  },
+  {
+    "number": "21",
+    "title": "Art Deco Luxe",
+    "mood": "Gold · Geometric",
+    "bestFor": "Luxury, gala events",
+    "id": "art-deco-luxe",
+    "background": [
+      "Deep black-brown: `#0E0A05`"
+    ],
+    "colors": [
+      {
+        "role": "Background",
+        "label": "Deep black-brown",
+        "hex": "#0E0A05"
+      },
+      {
+        "role": "Border / ornament",
+        "label": "Antique gold",
+        "hex": "#B8960C"
+      },
+      {
+        "role": "Title text",
+        "label": "Rich gold",
+        "hex": "#D4AA2A"
+      },
+      {
+        "role": "Subtitle",
+        "label": "Muted gold",
+        "hex": "#8A7020"
+      },
+      {
+        "role": "Diamond accent",
+        "label": "Bright gold",
+        "hex": "#B8960C"
+      }
+    ],
+    "fonts": [
+      "Title: **Cormorant Garamond / Trajan / Didot**, 26–36pt, wide letter-spacing 6–10pt",
+      "Caption: **Space Mono**, 9pt, 4–5pt letter-spacing",
+      "All text uppercase"
+    ],
+    "layout": [
+      "**Double inset gold border** frame (outer full, inner slightly inset)",
+      "**Fan / quarter-circle ornaments** in left and right mid-edge",
+      "Thin horizontal gold rule at vertical center",
+      "Diamond (rotated square) at rule-center intersection",
+      "Title centered, uppercase, wide-spaced"
+    ],
+    "signature": [
+      "Double inset border frame (two concentric rectangles)",
+      "Fan ornaments on sides",
+      "Diamond divider at center rule",
+      "ALL CAPS wide letter-spaced serif"
+    ],
+    "avoid": [
+      "Modern sans-serif fonts",
+      "Colorful or pastel tones",
+      "Asymmetric layouts"
+    ]
+  },
+  {
+    "number": "22",
+    "title": "Brutalist Newspaper",
+    "mood": "Editorial · Raw",
+    "bestFor": "Media, research",
+    "id": "brutalist-newspaper",
+    "background": [
+      "Aged paper off-white: `#F2EFE8`"
+    ],
+    "colors": [
+      {
+        "role": "Background",
+        "label": "Aged paper",
+        "hex": "#F2EFE8"
+      },
+      {
+        "role": "Masthead bar",
+        "label": "Deep warm black",
+        "hex": "#1A1208"
+      },
+      {
+        "role": "Masthead text",
+        "label": "Off-white",
+        "hex": "#F2EFE8"
+      },
+      {
+        "role": "Body text",
+        "label": "Dark warm brown",
+        "hex": "#3A3020"
+      },
+      {
+        "role": "Column divider",
+        "label": "Deep warm black",
+        "hex": "#1A1208"
+      }
+    ],
+    "fonts": [
+      "Masthead: **Space Mono Bold**, 12–14pt, tight",
+      "Headline: **Georgia Bold / Playfair Display Bold**, 20–28pt",
+      "Body: **Georgia**, 9–11pt, 1.5 line height",
+      "Date/label: **Space Mono**, 7–9pt, 1pt letter-spacing"
+    ],
+    "layout": [
+      "**Dark masthead bar** full-width at top (newspaper nameplate)",
+      "Double rule lines below masthead (3pt + 1pt)",
+      "**Two-column layout** with vertical divider rule",
+      "Left: headline + body text; Right: photo placeholder + caption"
+    ],
+    "signature": [
+      "Newspaper masthead bar",
+      "Double rule below masthead",
+      "Two-column layout with divider",
+      "Italic serif headline"
+    ],
+    "avoid": [
+      "Modern sans-serif fonts",
+      "Colorful elements",
+      "Clean white space (embrace density)"
+    ]
+  },
+  {
+    "number": "23",
+    "title": "Stained Glass Mosaic",
+    "mood": "Colorful · Artistic",
+    "bestFor": "Culture, museums",
+    "id": "stained-glass-mosaic",
+    "background": [
+      "Near-black grid frame: `#0A0A12`"
+    ],
+    "colors": [
+      {
+        "role": "Background",
+        "label": "Near-black (grout)",
+        "hex": "#0A0A12"
+      },
+      {
+        "role": "Cell 1",
+        "label": "Deep royal blue",
+        "hex": "#1A3A6E"
+      },
+      {
+        "role": "Cell 2",
+        "label": "Crimson",
+        "hex": "#E63030"
+      },
+      {
+        "role": "Cell 3",
+        "label": "Golden yellow",
+        "hex": "#F5D020"
+      },
+      {
+        "role": "Cell 4",
+        "label": "Forest green",
+        "hex": "#2A6E1A"
+      },
+      {
+        "role": "Cell 5",
+        "label": "Deep purple",
+        "hex": "#6E1A4E"
+      }
+    ],
+    "fonts": [
+      "Title overlay: **Cormorant Garamond Bold / Trajan**, 16–22pt, wide spacing",
+      "Body (below mosaic): **Georgia**, 13–15pt"
+    ],
+    "layout": [
+      "**6×4 (or similar) mosaic grid** covering full slide — 2pt dark gap between cells",
+      "Cells vary in color following a stained-glass color rhythm",
+      "Semi-transparent dark overlay to darken and unify",
+      "Slide title rendered as overlay text at bottom (light, wide-spaced)"
+    ],
+    "signature": [
+      "Dark \"grout\" gaps between all cells",
+      "No two adjacent cells the same color",
+      "Translucent overlay for text legibility"
+    ],
+    "avoid": [
+      "Pastel or muted cell colors",
+      "Large empty cells",
+      "Sans-serif overlay text"
+    ]
+  },
+  {
+    "number": "24",
+    "title": "Liquid Blob Morphing",
+    "mood": "Fluid · Organic Tech",
+    "bestFor": "Biotech, innovation",
+    "id": "liquid-blob-morphing",
+    "background": [
+      "Deep ocean gradient: `#0F2027 → #203A43 → #2C5364`"
+    ],
+    "colors": [
+      {
+        "role": "Background",
+        "label": "Deep ocean",
+        "hex": "#0F2027 → #2C5364"
+      },
+      {
+        "role": "Title",
+        "label": "White / near-white",
+        "hex": "#F0FFFE"
+      }
+    ],
+    "fonts": [
+      "Title: **Bebas Neue**, 36–48pt, 6pt letter-spacing",
+      "Body: **DM Mono / Space Mono**, 12–14pt",
+      "All text white"
+    ],
+    "layout": [
+      "3 large blurred blob shapes positioned asymmetrically (corners + center)",
+      "Blobs overlap with `multiply` or `screen` blend mode effect",
+      "Title centered with teal text glow",
+      "Optional: animated morphing border-radius effect"
+    ],
+    "signature": [
+      "Three overlapping blurred blobs (low opacity)",
+      "Ocean-depth dark background",
+      "Glowing white text with colored halo"
+    ],
+    "avoid": [
+      "Sharp geometric shapes",
+      "Bright or warm backgrounds",
+      "Dense text content"
+    ]
+  },
+  {
+    "number": "25",
+    "title": "Memphis Pop Pattern",
+    "mood": "80s · Geometric",
+    "bestFor": "Fashion, lifestyle",
+    "id": "memphis-pop-pattern",
+    "background": [
+      "Warm off-white: `#FFF5E0`"
+    ],
+    "colors": [
+      {
+        "role": "Background",
+        "label": "Warm off-white",
+        "hex": "#FFF5E0"
+      },
+      {
+        "role": "Triangle accent",
+        "label": "Crimson red",
+        "hex": "#E8344A"
+      },
+      {
+        "role": "Circle outline",
+        "label": "Royal blue",
+        "hex": "#1E90FF"
+      },
+      {
+        "role": "Zigzag bar",
+        "label": "Crimson red",
+        "hex": "#E8344A"
+      },
+      {
+        "role": "Dot accent",
+        "label": "Mint green",
+        "hex": "#22BB88"
+      },
+      {
+        "role": "Star/triangle 2",
+        "label": "Golden yellow",
+        "hex": "#FFD700"
+      }
+    ],
+    "fonts": [
+      "Title: **Bebas Neue / Futura ExtraBold**, 32–44pt",
+      "Body: **Futura / DM Sans**, 12–14pt"
+    ],
+    "layout": [
+      "**Scattered geometric shapes** (triangles, circles, dots, zigzags) across slide",
+      "No central focal point — distribute shapes with intentional asymmetry",
+      "Title placed over a slightly cleared zone in center",
+      "One zigzag bar cuts horizontally across the middle third"
+    ],
+    "signature": [
+      "Triangles, circles, dots, and zigzag bar all present",
+      "Warm off-white background (not pure white or dark)",
+      "Shapes feel random but are intentionally balanced"
+    ],
+    "avoid": [
+      "Minimalist compositions",
+      "Monochromatic palettes",
+      "Modern/clean fonts"
+    ]
+  },
+  {
+    "number": "26",
+    "title": "Dark Forest Nature",
+    "mood": "Mysterious · Atmospheric",
+    "bestFor": "Eco premium",
+    "id": "dark-forest-nature",
+    "background": [
+      "Radial dark gradient: `#0D2B14` center → `#060E08` edges"
+    ],
+    "colors": [
+      {
+        "role": "Background",
+        "label": "Deep forest black",
+        "hex": "#060E08"
+      },
+      {
+        "role": "Stars",
+        "label": "Pale green-white",
+        "hex": "#D4F0B0"
+      },
+      {
+        "role": "Title text",
+        "label": "Sage-white italic",
+        "hex": "rgba(200,255,180,0.85)"
+      }
+    ],
+    "fonts": [
+      "Title: **Playfair Display Italic / DM Serif Display Italic**, 20–28pt",
+      "Body: **EB Garamond**, 13–15pt",
+      "Caption: **Space Mono**, 9pt, wide spacing"
+    ],
+    "layout": [
+      "**Tree silhouettes** rising from bottom — triangular/fir shapes, 3+ overlapping depths",
+      "**Moon** top-right with soft radial glow",
+      "Star dots scattered sparingly in upper half",
+      "Mist gradient rising from bottom over trees",
+      "Italic serif title near bottom (above mist)"
+    ],
+    "signature": [
+      "Layered tree silhouettes (3+ depths)",
+      "Glowing moon top-right",
+      "Fog/mist gradient overlay",
+      "Italic serif text in sage-white"
+    ],
+    "avoid": [
+      "Bright greens (use near-black forest tones)",
+      "Hard edges on tree shapes",
+      "Sans-serif fonts"
+    ]
+  },
+  {
+    "number": "27",
+    "title": "Architectural Blueprint",
+    "mood": "Technical · Precise",
+    "bestFor": "Architecture",
+    "id": "architectural-blueprint",
+    "background": [
+      "Blueprint blue: `#0D2240`"
+    ],
+    "colors": [
+      {
+        "role": "Background",
+        "label": "Blueprint navy",
+        "hex": "#0D2240"
+      }
+    ],
+    "fonts": [
+      "All text: **Space Mono**, 8–12pt (no exceptions — monospace only)",
+      "Dimension annotations: 8pt",
+      "Title: 11–13pt, 4pt letter-spacing",
+      "Stamp: 8pt, multiline"
+    ],
+    "layout": [
+      "**Fine grid** (20pt) + **major grid** (60pt) layered",
+      "One or two geometric shapes with dimensions and annotation marks",
+      "Arrow dimension lines between key points",
+      "Circular stamp element (right side, mid-height)",
+      "Title as full-width label at bottom"
+    ],
+    "signature": [
+      "Dual grid (fine + major)",
+      "Dimension lines with annotation text",
+      "Circular blueprint stamp"
+    ],
+    "avoid": [
+      "Color or decorative elements",
+      "Non-monospace fonts",
+      "Photographic elements"
+    ]
+  },
+  {
+    "number": "28",
+    "title": "Maximalist Collage",
+    "mood": "Energetic · Layered",
+    "bestFor": "Advertising, fashion",
+    "id": "maximalist-collage",
+    "background": [
+      "Warm antique cream: `#E8DDD0` with diagonal pattern overlay"
+    ],
+    "colors": [
+      {
+        "role": "Background",
+        "label": "Antique cream",
+        "hex": "#E8DDD0"
+      },
+      {
+        "role": "Block 1",
+        "label": "Bold red",
+        "hex": "#E83030"
+      },
+      {
+        "role": "Block 2",
+        "label": "Near-black",
+        "hex": "#1A1A1A"
+      },
+      {
+        "role": "Block 3",
+        "label": "Acid yellow",
+        "hex": "#F5D020"
+      },
+      {
+        "role": "Text on red",
+        "label": "White",
+        "hex": "#FFFFFF"
+      },
+      {
+        "role": "Text on black",
+        "label": "White",
+        "hex": "#FFFFFF"
+      }
+    ],
+    "fonts": [
+      "Bold word: **Bebas Neue**, 24–34pt",
+      "Secondary: **Playfair Display Italic**, 16–22pt, vertical writing",
+      "Giant number: **Bebas Neue**, 64–80pt (ghost/watermark at 8% opacity)",
+      "Caption: **Space Mono**, 8pt"
+    ],
+    "layout": [
+      "**Overlapping color blocks** (3 blocks, each slightly rotated ±2–5°)",
+      "Each block contains one focused element (text, word, or icon)",
+      "Diagonal stripe pattern on background (3% opacity)",
+      "Ghost number lower-right",
+      "Circle outline accent element (outline only, one of the bold colors)"
+    ],
+    "signature": [
+      "3+ overlapping rotated blocks",
+      "Giant ghost number as texture",
+      "Circle outline accent",
+      "Vertical text in one block"
+    ],
+    "avoid": [
+      "Symmetric or centered compositions",
+      "Clean uncluttered layouts",
+      "Muted backgrounds"
+    ]
+  },
+  {
+    "number": "29",
+    "title": "SciFi Holographic Data",
+    "mood": "Hologram · HUD",
+    "bestFor": "AI, quantum",
+    "id": "scifi-holographic-data",
+    "background": [
+      "Deep space black: `#03050D`"
+    ],
+    "colors": [
+      {
+        "role": "Background",
+        "label": "Deep space",
+        "hex": "#03050D"
+      },
+      {
+        "role": "Bar elements",
+        "label": "Cyan gradient",
+        "hex": "transparent → #00C8FF → transparent"
+      },
+      {
+        "role": "Center dot",
+        "label": "Bright cyan",
+        "hex": "#00C8FF"
+      }
+    ],
+    "fonts": [
+      "All text: **Space Mono**, 9–11pt",
+      "System labels: 10pt, 3pt letter-spacing",
+      "Coordinates/data: 8pt"
+    ],
+    "layout": [
+      "**3 concentric rings** (full circles, varying opacity increasing inward)",
+      "Middle ring rotated 30° from outer ring",
+      "**Horizontal scan line** animating top to bottom (or static at mid position)",
+      "Horizontal bars (gradient center-glow) top and bottom",
+      "Center dot at ring intersection",
+      "Text labels at top-left and bottom-right"
+    ],
+    "signature": [
+      "3 concentric circles (not uniform — one rotated)",
+      "Scan line (animated or static)",
+      "All elements strictly monochromatic cyan"
+    ],
+    "avoid": [
+      "Multiple hue accents",
+      "Warm or saturated colors",
+      "Any decorative illustration"
+    ]
+  },
+  {
+    "number": "30",
+    "title": "Risograph Print",
+    "mood": "CMYK · Indie",
+    "bestFor": "Publishing, art",
+    "id": "risograph-print",
+    "background": [
+      "Aged paper: `#F7F2E8`"
+    ],
+    "colors": [
+      {
+        "role": "Background",
+        "label": "Aged paper",
+        "hex": "#F7F2E8"
+      },
+      {
+        "role": "Circle 1 (C)",
+        "label": "Riso red",
+        "hex": "#E8344A"
+      },
+      {
+        "role": "Circle 2 (M)",
+        "label": "Riso blue",
+        "hex": "#0D5C9E"
+      },
+      {
+        "role": "Circle 3 (Y)",
+        "label": "Riso yellow",
+        "hex": "#F5D020"
+      }
+    ],
+    "fonts": [
+      "Main title: **Bebas Neue**, 34–44pt, 4pt letter-spacing",
+      "Caption: **Space Mono**, 9pt"
+    ],
+    "layout": [
+      "**Three overlapping circles** (CMYK primary colors) in center third",
+      "Each circle uses `multiply` blend mode — overlaps create secondary colors naturally",
+      "**Offset ghost text** behind main title (3–4pt shift, low opacity, accent color)",
+      "Main title centered above circles",
+      "Monospace caption at bottom"
+    ],
+    "signature": [
+      "Three overlapping multiply-blend circles",
+      "Offset ghost title (registration mark error simulation)",
+      "Warm paper background"
+    ],
+    "avoid": [
+      "Digital-looking crisp shapes",
+      "Dark backgrounds",
+      "Screen-blend mode (must be multiply for authentic CMYK overlap)"
+    ]
+  }
+];

--- a/src/design-styles.js
+++ b/src/design-styles.js
@@ -1,0 +1,387 @@
+import { RAW_DESIGN_STYLES } from './design-styles-data.js';
+
+export const DESIGN_STYLES_SOURCE = Object.freeze({
+  name: 'PPT Design Collections',
+  repo: 'corazzon/pptx-design-styles',
+  url: 'https://github.com/corazzon/pptx-design-styles',
+  previewUrl: 'https://corazzon.github.io/pptx-design-styles/preview/modern-pptx-designs-30.html',
+  references: [
+    'README.md',
+    'preview/modern-pptx-designs-30.html',
+    'references/styles.md',
+  ],
+  license: 'MIT',
+  citation: 'Design collections derived from corazzon/pptx-design-styles.',
+});
+
+const STYLE_GUIDE = Object.freeze([
+  {
+    goal: 'Tech / AI / Startup',
+    recommended: ['glassmorphism', 'aurora-neon-glow', 'cyberpunk-outline-hud', 'scifi-holographic-data'],
+  },
+  {
+    goal: 'Corporate / Finance',
+    recommended: ['swiss-international', 'monochrome-minimal', 'editorial-magazine'],
+  },
+  {
+    goal: 'Brand / Marketing',
+    recommended: ['gradient-mesh', 'typographic-bold', 'duotone-color-split'],
+  },
+  {
+    goal: 'Product / App / UX',
+    recommended: ['bento-grid', 'claymorphism', 'pastel-soft-ui'],
+  },
+  {
+    goal: 'Entertainment / Gaming',
+    recommended: ['retro-y2k', 'dark-neon-miami', 'vaporwave', 'memphis-pop-pattern'],
+  },
+  {
+    goal: 'Eco / Wellness',
+    recommended: ['hand-crafted-organic', 'nordic-minimalism', 'dark-forest-nature'],
+  },
+  {
+    goal: 'Luxury / Premium',
+    recommended: ['art-deco-luxe', 'monochrome-minimal', 'dark-academia'],
+  },
+  {
+    goal: 'Science / Biotech',
+    recommended: ['liquid-blob-morphing', 'scifi-holographic-data', 'aurora-neon-glow'],
+  },
+]);
+
+const DESIGN_STYLES = RAW_DESIGN_STYLES.map((style) => Object.freeze({
+  ...style,
+  source: DESIGN_STYLES_SOURCE,
+}));
+
+const DESIGN_STYLES_BY_ID = new Map(DESIGN_STYLES.map((style) => [style.id, style]));
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+function renderList(items = []) {
+  return items.map((item) => `<li>${escapeHtml(item)}</li>`).join('');
+}
+
+function renderPalette(colors = []) {
+  return colors.map((color) => `
+    <li class="palette-item">
+      <span class="swatch" style="background:${escapeHtml(color.hex)}"></span>
+      <div>
+        <strong>${escapeHtml(color.label)}</strong>
+        <div>${escapeHtml(color.role)} · ${escapeHtml(color.hex)}</div>
+      </div>
+    </li>
+  `).join('');
+}
+
+function renderStyleCard(style, selectedStyleId) {
+  const isSelected = style.id === selectedStyleId;
+  return `
+    <article class="style-card${isSelected ? ' style-card-selected' : ''}">
+      <div class="style-card-header">
+        <div>
+          <p class="eyebrow">Style ${escapeHtml(style.number)}</p>
+          <h2>${escapeHtml(style.title)}</h2>
+          <p class="meta">${escapeHtml(style.id)} · ${escapeHtml(style.mood)} · Best for ${escapeHtml(style.bestFor)}</p>
+        </div>
+        ${isSelected ? '<p class="selected-badge">Selected style</p>' : ''}
+      </div>
+      <section>
+        <h3>Background</h3>
+        <ul>${renderList(style.background)}</ul>
+      </section>
+      <section>
+        <h3>Palette</h3>
+        <ul class="palette">${renderPalette(style.colors)}</ul>
+      </section>
+      <section>
+        <h3>Fonts</h3>
+        <ul>${renderList(style.fonts)}</ul>
+      </section>
+      <section>
+        <h3>Layout</h3>
+        <ul>${renderList(style.layout)}</ul>
+      </section>
+      <section>
+        <h3>Signature elements</h3>
+        <ul>${renderList(style.signature)}</ul>
+      </section>
+      <section>
+        <h3>Avoid</h3>
+        <ul>${renderList(style.avoid)}</ul>
+      </section>
+      <div class="style-card-footer">
+        <code>slides-grab preview-styles --style ${escapeHtml(style.id)}</code>
+        <code>slides-grab select-style ${escapeHtml(style.id)}</code>
+      </div>
+    </article>
+  `;
+}
+
+function renderSelectionGuide() {
+  return STYLE_GUIDE.map((entry) => `
+    <li>
+      <strong>${escapeHtml(entry.goal)}</strong>
+      <span>${escapeHtml(entry.recommended.join(', '))}</span>
+    </li>
+  `).join('');
+}
+
+export function listDesignStyles() {
+  return DESIGN_STYLES;
+}
+
+export function getDesignStyle(styleId) {
+  if (!styleId) {
+    return null;
+  }
+  return DESIGN_STYLES_BY_ID.get(styleId) ?? null;
+}
+
+export function requireDesignStyle(styleId) {
+  const style = getDesignStyle(styleId);
+  if (!style) {
+    throw new Error(`Unknown style "${styleId}". Run "slides-grab list-styles" to inspect the bundled collection.`);
+  }
+  return style;
+}
+
+export function buildStylePreviewHtml({ styleId, styles, selectedStyleId } = {}) {
+  const resolvedStyles = styles ?? (styleId ? [requireDesignStyle(styleId)] : listDesignStyles());
+  const resolvedSelectedStyleId = selectedStyleId ?? styleId ?? null;
+  const selectedStyle = resolvedSelectedStyleId ? getDesignStyle(resolvedSelectedStyleId) : null;
+  const title = resolvedStyles.length === 1
+    ? `${resolvedStyles[0].title} — slides-grab design preview`
+    : `Previewing ${resolvedStyles.length} bundled design styles`;
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${escapeHtml(title)}</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #0b1020;
+      --surface: rgba(11, 16, 32, 0.8);
+      --surface-strong: rgba(17, 24, 39, 0.95);
+      --border: rgba(148, 163, 184, 0.24);
+      --text: #e2e8f0;
+      --muted: #94a3b8;
+      --accent: #7dd3fc;
+      --accent-strong: #38bdf8;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      padding: 32px;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background:
+        radial-gradient(circle at top left, rgba(56, 189, 248, 0.22), transparent 28%),
+        radial-gradient(circle at top right, rgba(167, 139, 250, 0.18), transparent 24%),
+        linear-gradient(180deg, #020617 0%, var(--bg) 100%);
+      color: var(--text);
+      line-height: 1.6;
+    }
+    a { color: var(--accent); }
+    code {
+      display: inline-block;
+      padding: 6px 10px;
+      border-radius: 999px;
+      background: rgba(15, 23, 42, 0.8);
+      border: 1px solid var(--border);
+      font-size: 0.92rem;
+    }
+    .hero {
+      display: grid;
+      gap: 18px;
+      margin-bottom: 28px;
+      padding: 24px;
+      border-radius: 24px;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      box-shadow: 0 24px 80px rgba(15, 23, 42, 0.4);
+      backdrop-filter: blur(18px);
+    }
+    .hero h1 {
+      margin: 0;
+      font-size: clamp(2rem, 5vw, 3.4rem);
+      line-height: 1.05;
+    }
+    .hero p {
+      margin: 0;
+      color: var(--muted);
+      max-width: 70ch;
+    }
+    .hero-grid {
+      display: grid;
+      gap: 16px;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    }
+    .hero-panel {
+      padding: 18px;
+      border-radius: 20px;
+      background: var(--surface-strong);
+      border: 1px solid var(--border);
+    }
+    .hero-panel h2,
+    .hero-panel h3,
+    .style-card h3 {
+      margin: 0 0 8px;
+      font-size: 1rem;
+      letter-spacing: 0.01em;
+    }
+    .hero-panel ul,
+    .style-card ul {
+      margin: 0;
+      padding-left: 18px;
+    }
+    .hero-panel li,
+    .style-card li { color: var(--muted); }
+    .selection-guide {
+      display: grid;
+      gap: 10px;
+      padding-left: 0;
+      list-style: none;
+    }
+    .selection-guide li {
+      display: grid;
+      gap: 4px;
+      padding: 12px 14px;
+      border-radius: 16px;
+      background: rgba(15, 23, 42, 0.7);
+      border: 1px solid var(--border);
+    }
+    .styles-grid {
+      display: grid;
+      gap: 18px;
+      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      align-items: start;
+    }
+    .style-card {
+      padding: 22px;
+      border-radius: 22px;
+      background: rgba(15, 23, 42, 0.78);
+      border: 1px solid var(--border);
+      box-shadow: 0 18px 56px rgba(2, 6, 23, 0.25);
+    }
+    .style-card-selected {
+      border-color: rgba(125, 211, 252, 0.85);
+      box-shadow: 0 0 0 1px rgba(125, 211, 252, 0.55), 0 18px 56px rgba(2, 6, 23, 0.25);
+    }
+    .style-card-header {
+      display: flex;
+      justify-content: space-between;
+      gap: 16px;
+      align-items: flex-start;
+      margin-bottom: 18px;
+    }
+    .style-card h2 {
+      margin: 0 0 6px;
+      font-size: 1.55rem;
+      line-height: 1.1;
+    }
+    .style-card .meta,
+    .eyebrow {
+      margin: 0;
+      color: var(--muted);
+    }
+    .eyebrow {
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      font-size: 0.72rem;
+      margin-bottom: 8px;
+    }
+    .selected-badge {
+      margin: 0;
+      padding: 8px 12px;
+      border-radius: 999px;
+      background: rgba(56, 189, 248, 0.12);
+      border: 1px solid rgba(56, 189, 248, 0.4);
+      color: var(--accent);
+      white-space: nowrap;
+      font-weight: 700;
+    }
+    .palette {
+      display: grid;
+      gap: 12px;
+      padding-left: 0;
+      list-style: none;
+    }
+    .palette-item {
+      display: flex;
+      gap: 12px;
+      align-items: center;
+    }
+    .swatch {
+      width: 26px;
+      height: 26px;
+      border-radius: 999px;
+      border: 1px solid rgba(255, 255, 255, 0.18);
+      flex: none;
+    }
+    .style-card-footer {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      margin-top: 18px;
+    }
+    footer {
+      margin-top: 28px;
+      color: var(--muted);
+      font-size: 0.95rem;
+    }
+    @media (max-width: 720px) {
+      body { padding: 18px; }
+      .style-card-header { flex-direction: column; }
+    }
+  </style>
+</head>
+<body>
+  <section class="hero">
+    <div>
+      <p class="eyebrow">slides-grab design collections</p>
+      <h1>${escapeHtml(title)}</h1>
+      <p>
+        Bundled style references derived from <a href="${escapeHtml(DESIGN_STYLES_SOURCE.url)}">${escapeHtml(DESIGN_STYLES_SOURCE.repo)}</a>.
+        This keeps the design-library idea in scope without adding a separate GUI: list styles in the CLI, generate this local preview page when needed, and persist one choice in <code>style-config.json</code> before slide generation.
+      </p>
+    </div>
+    <div class="hero-grid">
+      <section class="hero-panel">
+        <h2>Suggested workflow</h2>
+        <ul>
+          <li>Ask the agent to shortlist 2–4 styles based on mood and best-for notes.</li>
+          <li>Run <code>slides-grab preview-styles</code> or <code>slides-grab preview-styles --style &lt;id&gt;</code> for a local HTML gallery.</li>
+          <li>Approve one direction with <code>slides-grab select-style &lt;id&gt;</code> before generating slides.</li>
+          <li>Change the selection anytime before regenerating or revising slides.</li>
+        </ul>
+      </section>
+      <section class="hero-panel">
+        <h3>Selection guide</h3>
+        <ul class="selection-guide">${renderSelectionGuide()}</ul>
+      </section>
+      <section class="hero-panel">
+        <h3>Current selection</h3>
+        <p>${selectedStyle ? `${escapeHtml(selectedStyle.title)} (${escapeHtml(selectedStyle.id)})` : 'No style selected yet.'}</p>
+        <p>Reference sources: ${DESIGN_STYLES_SOURCE.references.map((item) => `<code>${escapeHtml(item)}</code>`).join(' ')}</p>
+      </section>
+    </div>
+  </section>
+  <section class="styles-grid">
+    ${resolvedStyles.map((style) => renderStyleCard(style, resolvedSelectedStyleId)).join('')}
+  </section>
+  <footer>
+    <p>Attribution preserved from ${escapeHtml(DESIGN_STYLES_SOURCE.repo)} (${escapeHtml(DESIGN_STYLES_SOURCE.license)}). Preview source: <a href="${escapeHtml(DESIGN_STYLES_SOURCE.previewUrl)}">${escapeHtml(DESIGN_STYLES_SOURCE.previewUrl)}</a>.</p>
+  </footer>
+</body>
+</html>`;
+}

--- a/src/resolve.js
+++ b/src/resolve.js
@@ -5,7 +5,7 @@
  *   1. Local (user's CWD) — per-project overrides
  *   2. Package root — built-in defaults
  *
- * slides directory, slide-outline.md, style-config.md → always local (CWD)
+ * slides directory, slide-outline.md, style-config.json → always local (CWD)
  * templates/, themes/ → local first, package fallback
  * scripts/ → always package
  */

--- a/src/style-config.js
+++ b/src/style-config.js
@@ -1,7 +1,7 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 
-import { DESIGN_STYLES_SOURCE, requireDesignStyle } from './design-styles.js';
+import { DESIGN_STYLES_SOURCE, getDesignStyle, requireDesignStyle } from './design-styles.js';
 
 export const STYLE_CONFIG_FILE = 'style-config.json';
 
@@ -9,18 +9,25 @@ export function getStyleConfigPath(cwd = process.cwd()) {
   return resolve(cwd, STYLE_CONFIG_FILE);
 }
 
-export async function readSelectedStyleConfig(cwd = process.cwd()) {
+export async function readSelectedStyleConfig(cwd = process.cwd(), options = {}) {
   try {
+    const { allowInvalidSelection = false } = options;
     const configPath = getStyleConfigPath(cwd);
     const rawText = await readFile(configPath, 'utf-8');
     const parsed = JSON.parse(rawText);
     const selectedStyleId = parsed.selectedStyleId ?? parsed.style?.id ?? null;
+    const style = selectedStyleId ? getDesignStyle(selectedStyleId) : null;
+
+    if (selectedStyleId && !style && !allowInvalidSelection) {
+      requireDesignStyle(selectedStyleId);
+    }
 
     return {
       ...parsed,
       path: configPath,
       selectedStyleId,
-      style: selectedStyleId ? requireDesignStyle(selectedStyleId) : null,
+      style,
+      invalidSelectedStyleId: selectedStyleId && !style ? selectedStyleId : null,
     };
   } catch (error) {
     if (error && error.code === 'ENOENT') {

--- a/src/style-config.js
+++ b/src/style-config.js
@@ -1,0 +1,50 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+
+import { DESIGN_STYLES_SOURCE, requireDesignStyle } from './design-styles.js';
+
+export const STYLE_CONFIG_FILE = 'style-config.json';
+
+export function getStyleConfigPath(cwd = process.cwd()) {
+  return resolve(cwd, STYLE_CONFIG_FILE);
+}
+
+export async function readSelectedStyleConfig(cwd = process.cwd()) {
+  try {
+    const configPath = getStyleConfigPath(cwd);
+    const rawText = await readFile(configPath, 'utf-8');
+    const parsed = JSON.parse(rawText);
+    const selectedStyleId = parsed.selectedStyleId ?? parsed.style?.id ?? null;
+
+    return {
+      ...parsed,
+      path: configPath,
+      selectedStyleId,
+      style: selectedStyleId ? requireDesignStyle(selectedStyleId) : null,
+    };
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      return null;
+    }
+    throw error;
+  }
+}
+
+export async function writeSelectedStyleConfig({ cwd = process.cwd(), style }) {
+  const selectedStyle = typeof style === 'string' ? requireDesignStyle(style) : requireDesignStyle(style?.id);
+  const configPath = getStyleConfigPath(cwd);
+  const config = {
+    selectedStyleId: selectedStyle.id,
+    updatedAt: new Date().toISOString(),
+    source: DESIGN_STYLES_SOURCE,
+    style: selectedStyle,
+  };
+
+  await mkdir(dirname(configPath), { recursive: true });
+  await writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf-8');
+
+  return {
+    ...config,
+    path: configPath,
+  };
+}

--- a/templates/design-styles/README.md
+++ b/templates/design-styles/README.md
@@ -1,0 +1,20 @@
+# Design Style Collections
+
+slides-grab bundles 30 design collections derived from [corazzon/pptx-design-styles](https://github.com/corazzon/pptx-design-styles) (MIT).
+
+These collections are reference directions for slide generation, not drop-in HTML slide templates.
+
+## Recommended workflow
+
+1. `slides-grab list-styles`
+2. `slides-grab preview-styles --style <id>` when you want a richer preview
+3. `slides-grab select-style <id>` before generating slides
+4. Keep or update `style-config.json` as the approved design direction for the deck
+
+The preview/select flow is intentionally simple: it keeps design approval inside the CLI and a local HTML preview page instead of adding a separate app.
+
+## Citation
+
+- Upstream collection: `corazzon/pptx-design-styles`
+- URL: <https://github.com/corazzon/pptx-design-styles>
+- Reference used in this repo: `references/styles.md`

--- a/tests/design/design-styles.test.js
+++ b/tests/design/design-styles.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { execFileSync, spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -74,6 +74,53 @@ test('slides-grab help exposes style discovery commands', () => {
   assert.match(output, /list-styles/);
   assert.match(output, /preview-styles/);
   assert.match(output, /select-style/);
+});
+
+test('style discovery commands support --slides-dir workspaces', () => {
+  const workspace = makeWorkspace();
+  const slidesDir = path.join('decks', 'demo');
+  const configPath = path.join(workspace, slidesDir, STYLE_CONFIG_FILE);
+  const previewPath = path.join(workspace, slidesDir, 'style-preview.html');
+
+  try {
+    const selectOutput = execFileSync(
+      process.execPath,
+      [cliPath, 'select-style', 'glassmorphism', '--slides-dir', slidesDir],
+      {
+        cwd: workspace,
+        encoding: 'utf-8',
+      },
+    );
+
+    assert.match(selectOutput, /Saved selection to .*decks[\/]demo[\/]style-config\.json/);
+    assert.ok(existsSync(configPath));
+
+    const listOutput = execFileSync(
+      process.execPath,
+      [cliPath, 'list-styles', '--slides-dir', slidesDir],
+      {
+        cwd: workspace,
+        encoding: 'utf-8',
+      },
+    );
+
+    assert.match(listOutput, /glassmorphism/);
+    assert.match(listOutput, /selected/i);
+
+    const previewOutput = execFileSync(
+      process.execPath,
+      [cliPath, 'preview-styles', '--slides-dir', slidesDir],
+      {
+        cwd: workspace,
+        encoding: 'utf-8',
+      },
+    );
+
+    assert.match(previewOutput, /Wrote style preview catalog/i);
+    assert.ok(existsSync(previewPath));
+  } finally {
+    rmSync(workspace, { recursive: true, force: true });
+  }
 });
 
 test('slides-grab preview-styles writes a local html gallery', () => {
@@ -164,6 +211,32 @@ test('slides-grab select-style writes the local style config and list-styles mar
 
     assert.match(listOutput, /neo-brutalism/);
     assert.match(listOutput, /selected/i);
+  } finally {
+    rmSync(workspace, { recursive: true, force: true });
+  }
+});
+
+test('stale style-config entries do not block list or preview recovery', () => {
+  const workspace = makeWorkspace();
+  const outputPath = path.join(workspace, 'style-catalog.html');
+  const configPath = path.join(workspace, STYLE_CONFIG_FILE);
+
+  try {
+    writeFileSync(configPath, `${JSON.stringify({ selectedStyleId: 'unknown-style' }, null, 2)}\n`, 'utf-8');
+
+    const listOutput = execFileSync(process.execPath, [cliPath, 'list-styles'], {
+      cwd: workspace,
+      encoding: 'utf-8',
+    });
+    const previewOutput = execFileSync(process.execPath, [cliPath, 'preview-styles', '--output', outputPath], {
+      cwd: workspace,
+      encoding: 'utf-8',
+    });
+
+    assert.match(listOutput, /Available design styles:/);
+    assert.match(listOutput, /unknown-style/);
+    assert.match(previewOutput, /Ignoring saved style selection/i);
+    assert.match(readFileSync(outputPath, 'utf-8'), /Previewing 30 bundled design styles/i);
   } finally {
     rmSync(workspace, { recursive: true, force: true });
   }

--- a/tests/design/design-styles.test.js
+++ b/tests/design/design-styles.test.js
@@ -26,6 +26,10 @@ function makeWorkspace(prefix = 'slides-grab-style-test-') {
   return mkdtempSync(path.join(tmpdir(), prefix));
 }
 
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 test('bundled design styles preserve upstream citation metadata', () => {
   const styles = listDesignStyles();
 
@@ -198,6 +202,7 @@ test('command hints quote --slides-dir values with spaces', () => {
   const workspace = makeWorkspace();
   const slidesDir = path.join('decks', 'my demo');
   const configPath = path.join(workspace, slidesDir, STYLE_CONFIG_FILE);
+  const quotedSlidesDirPattern = `'${escapeRegExp(slidesDir)}'`;
 
   try {
     const selectOutput = execFileSync(
@@ -220,8 +225,14 @@ test('command hints quote --slides-dir values with spaces', () => {
       },
     );
 
-    assert.match(selectOutput, /preview-styles --style glassmorphism --slides-dir 'decks\/my demo'/);
-    assert.match(listOutput, /select-style <id> --slides-dir 'decks\/my demo'/);
+    assert.match(
+      selectOutput,
+      new RegExp(`preview-styles --style glassmorphism --slides-dir ${quotedSlidesDirPattern}`),
+    );
+    assert.match(
+      listOutput,
+      new RegExp(`select-style <id> --slides-dir ${quotedSlidesDirPattern}`),
+    );
   } finally {
     rmSync(workspace, { recursive: true, force: true });
   }

--- a/tests/design/design-styles.test.js
+++ b/tests/design/design-styles.test.js
@@ -146,6 +146,54 @@ test('slides-grab preview-styles writes a local html gallery', () => {
   }
 });
 
+test('preview-styles keeps explicit relative --output paths rooted at cwd even with --slides-dir', () => {
+  const workspace = makeWorkspace();
+  const slidesDir = path.join('decks', 'demo');
+  const outputPath = path.join(workspace, 'custom-preview.html');
+  const rebasedPath = path.join(workspace, slidesDir, 'custom-preview.html');
+
+  try {
+    const output = execFileSync(
+      process.execPath,
+      [cliPath, 'preview-styles', '--slides-dir', slidesDir, '--output', 'custom-preview.html'],
+      {
+        cwd: workspace,
+        encoding: 'utf-8',
+      },
+    );
+
+    assert.match(output, /Wrote style preview catalog to .*custom-preview\.html/i);
+    assert.ok(existsSync(outputPath));
+    assert.equal(existsSync(rebasedPath), false);
+    assert.match(readFileSync(outputPath, 'utf-8'), /Previewing 30 bundled design styles/i);
+  } finally {
+    rmSync(workspace, { recursive: true, force: true });
+  }
+});
+
+test('preview-styles treats explicit --output style-preview.html as cwd-relative with --slides-dir', () => {
+  const workspace = makeWorkspace();
+  const slidesDir = path.join('decks', 'demo');
+  const outputPath = path.join(workspace, 'style-preview.html');
+  const rebasedPath = path.join(workspace, slidesDir, 'style-preview.html');
+
+  try {
+    execFileSync(
+      process.execPath,
+      [cliPath, 'preview-styles', '--slides-dir', slidesDir, '--output', 'style-preview.html'],
+      {
+        cwd: workspace,
+        encoding: 'utf-8',
+      },
+    );
+
+    assert.ok(existsSync(outputPath));
+    assert.equal(existsSync(rebasedPath), false);
+  } finally {
+    rmSync(workspace, { recursive: true, force: true });
+  }
+});
+
 test('slides-grab preview-styles without --style renders the full catalog', () => {
   const workspace = makeWorkspace();
   const outputPath = path.join(workspace, 'style-catalog.html');

--- a/tests/design/design-styles.test.js
+++ b/tests/design/design-styles.test.js
@@ -194,6 +194,39 @@ test('preview-styles treats explicit --output style-preview.html as cwd-relative
   }
 });
 
+test('command hints quote --slides-dir values with spaces', () => {
+  const workspace = makeWorkspace();
+  const slidesDir = path.join('decks', 'my demo');
+  const configPath = path.join(workspace, slidesDir, STYLE_CONFIG_FILE);
+
+  try {
+    const selectOutput = execFileSync(
+      process.execPath,
+      [cliPath, 'select-style', 'glassmorphism', '--slides-dir', slidesDir],
+      {
+        cwd: workspace,
+        encoding: 'utf-8',
+      },
+    );
+
+    writeFileSync(configPath, `${JSON.stringify({ selectedStyleId: 'unknown-style' }, null, 2)}\n`, 'utf-8');
+
+    const listOutput = execFileSync(
+      process.execPath,
+      [cliPath, 'list-styles', '--slides-dir', slidesDir],
+      {
+        cwd: workspace,
+        encoding: 'utf-8',
+      },
+    );
+
+    assert.match(selectOutput, /preview-styles --style glassmorphism --slides-dir 'decks\/my demo'/);
+    assert.match(listOutput, /select-style <id> --slides-dir 'decks\/my demo'/);
+  } finally {
+    rmSync(workspace, { recursive: true, force: true });
+  }
+});
+
 test('slides-grab preview-styles without --style renders the full catalog', () => {
   const workspace = makeWorkspace();
   const outputPath = path.join(workspace, 'style-catalog.html');

--- a/tests/design/design-styles.test.js
+++ b/tests/design/design-styles.test.js
@@ -1,0 +1,186 @@
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+import {
+  DESIGN_STYLES_SOURCE,
+  buildStylePreviewHtml,
+  getDesignStyle,
+  listDesignStyles,
+} from '../../src/design-styles.js';
+import {
+  STYLE_CONFIG_FILE,
+  getStyleConfigPath,
+  readSelectedStyleConfig,
+  writeSelectedStyleConfig,
+} from '../../src/style-config.js';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const cliPath = path.join(repoRoot, 'bin', 'ppt-agent.js');
+
+function makeWorkspace(prefix = 'slides-grab-style-test-') {
+  return mkdtempSync(path.join(tmpdir(), prefix));
+}
+
+test('bundled design styles preserve upstream citation metadata', () => {
+  const styles = listDesignStyles();
+
+  assert.equal(styles.length, 30);
+  assert.equal(styles[0].id, 'glassmorphism');
+  assert.equal(styles[0].source.repo, 'corazzon/pptx-design-styles');
+  assert.equal(DESIGN_STYLES_SOURCE.repo, 'corazzon/pptx-design-styles');
+  assert.match(DESIGN_STYLES_SOURCE.url, /corazzon\/pptx-design-styles/);
+});
+
+test('preview html includes the selected style and upstream citation', () => {
+  const style = getDesignStyle('glassmorphism');
+  const html = buildStylePreviewHtml({ styles: [style], selectedStyleId: style.id });
+
+  assert.match(html, /Glassmorphism/);
+  assert.match(html, /corazzon\/pptx-design-styles/);
+  assert.match(html, /slides-grab select-style glassmorphism/);
+  assert.match(html, /Selected style/);
+});
+
+test('selected style config round-trips to the local workspace', async () => {
+  const workspace = makeWorkspace();
+
+  try {
+    const style = getDesignStyle('neo-brutalism');
+    const configPath = getStyleConfigPath(workspace);
+
+    await writeSelectedStyleConfig({ cwd: workspace, style });
+    assert.equal(configPath, path.join(workspace, STYLE_CONFIG_FILE));
+    assert.ok(existsSync(configPath));
+
+    const config = await readSelectedStyleConfig(workspace);
+    assert.equal(config.style.id, 'neo-brutalism');
+    assert.equal(config.style.source.repo, 'corazzon/pptx-design-styles');
+  } finally {
+    rmSync(workspace, { recursive: true, force: true });
+  }
+});
+
+test('slides-grab help exposes style discovery commands', () => {
+  const output = execFileSync(process.execPath, ['bin/ppt-agent.js', '--help'], {
+    cwd: repoRoot,
+    encoding: 'utf-8',
+  });
+
+  assert.match(output, /list-styles/);
+  assert.match(output, /preview-styles/);
+  assert.match(output, /select-style/);
+});
+
+test('slides-grab preview-styles writes a local html gallery', () => {
+  const workspace = makeWorkspace();
+  const outputPath = path.join(workspace, 'style-preview.html');
+
+  try {
+    const output = execFileSync(
+      process.execPath,
+      [cliPath, 'preview-styles', '--style', 'glassmorphism', '--output', outputPath],
+      {
+        cwd: workspace,
+        encoding: 'utf-8',
+      },
+    );
+
+    const html = readFileSync(outputPath, 'utf-8');
+    assert.match(output, /Wrote style preview/i);
+    assert.match(html, /Glassmorphism/);
+    assert.match(html, /corazzon\/pptx-design-styles/);
+  } finally {
+    rmSync(workspace, { recursive: true, force: true });
+  }
+});
+
+test('slides-grab preview-styles without --style renders the full catalog', () => {
+  const workspace = makeWorkspace();
+  const outputPath = path.join(workspace, 'style-catalog.html');
+
+  try {
+    execFileSync(process.execPath, [cliPath, 'preview-styles', '--output', outputPath], {
+      cwd: workspace,
+      encoding: 'utf-8',
+    });
+
+    const html = readFileSync(outputPath, 'utf-8');
+    assert.match(html, /Previewing 30 bundled design styles/i);
+    assert.match(html, /neo-brutalism/i);
+    assert.match(html, /glassmorphism/i);
+  } finally {
+    rmSync(workspace, { recursive: true, force: true });
+  }
+});
+
+
+test('preview-styles without --style highlights the currently selected style when config exists', () => {
+  const workspace = makeWorkspace();
+  const outputPath = path.join(workspace, 'style-catalog.html');
+
+  try {
+    execFileSync(process.execPath, [cliPath, 'select-style', 'neo-brutalism'], {
+      cwd: workspace,
+      encoding: 'utf-8',
+    });
+    execFileSync(process.execPath, [cliPath, 'preview-styles', '--output', outputPath], {
+      cwd: workspace,
+      encoding: 'utf-8',
+    });
+
+    const html = readFileSync(outputPath, 'utf-8');
+    assert.match(html, /Neo-Brutalism/);
+    assert.match(html, /Selected style/);
+  } finally {
+    rmSync(workspace, { recursive: true, force: true });
+  }
+});
+
+test('slides-grab select-style writes the local style config and list-styles marks it', () => {
+  const workspace = makeWorkspace();
+
+  try {
+    const selectOutput = execFileSync(
+      process.execPath,
+      [cliPath, 'select-style', 'neo-brutalism'],
+      {
+        cwd: workspace,
+        encoding: 'utf-8',
+      },
+    );
+
+    assert.match(selectOutput, /Selected style: Neo-Brutalism/);
+    assert.ok(existsSync(path.join(workspace, STYLE_CONFIG_FILE)));
+
+    const listOutput = execFileSync(process.execPath, [cliPath, 'list-styles'], {
+      cwd: workspace,
+      encoding: 'utf-8',
+    });
+
+    assert.match(listOutput, /neo-brutalism/);
+    assert.match(listOutput, /selected/i);
+  } finally {
+    rmSync(workspace, { recursive: true, force: true });
+  }
+});
+
+test('invalid style ids fail cleanly', () => {
+  const workspace = makeWorkspace();
+
+  try {
+    const result = spawnSync(process.execPath, [cliPath, 'select-style', 'not-a-style'], {
+      cwd: workspace,
+      encoding: 'utf-8',
+    });
+
+    assert.notEqual(result.status, 0);
+    assert.match(`${result.stderr}\n${result.stdout}`, /unknown style/i);
+  } finally {
+    rmSync(workspace, { recursive: true, force: true });
+  }
+});

--- a/tests/figma/figma-export.test.js
+++ b/tests/figma/figma-export.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import test from 'node:test';
@@ -172,24 +172,21 @@ test('packed npm install can execute slides-grab figma without missing runtime m
   const installRoot = mkdtempSync(join(tmpdir(), 'slides-grab-pack-install-'));
 
   try {
-    const output = execFileSync('npm', ['pack', '--json'], {
+    mkdirSync(packRoot, { recursive: true });
+    mkdirSync(installRoot, { recursive: true });
+
+    const output = execFileSync('npm', ['pack', '--json', '--pack-destination', packRoot], {
       cwd: process.cwd(),
       encoding: 'utf-8',
     });
     const [packInfo] = JSON.parse(output);
-    const tarballName = packInfo.filename;
-    const tarballPath = join(process.cwd(), tarballName);
-    const storedTarballPath = join(packRoot, tarballName);
+    const storedTarballPath = join(packRoot, packInfo.filename);
 
-    mkdirSync(packRoot, { recursive: true });
-    mkdirSync(installRoot, { recursive: true });
     writeFileSync(
       join(installRoot, 'package.json'),
       JSON.stringify({ name: 'slides-grab-pack-smoke', private: true }, null, 2),
       'utf-8',
     );
-
-    renameSync(tarballPath, storedTarballPath);
 
     execFileSync('npm', ['install', '--no-package-lock', storedTarballPath], {
       cwd: installRoot,

--- a/tests/skills/installable-skills.test.js
+++ b/tests/skills/installable-skills.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
@@ -40,6 +40,7 @@ test('npm pack includes bundled skill references for installable skills', () => 
   assert.ok(filePaths.has('skills/slides-grab-export/references/html2pptx.md'));
   assert.ok(filePaths.has('skills/slides-grab-export/references/ooxml.md'));
   assert.ok(filePaths.has('skills/slides-grab/references/presentation-workflow-reference.md'));
+  assert.ok(filePaths.has('templates/design-styles/README.md'));
   assert.ok(filePaths.has('scripts/generate-image.js'));
   assert.ok(filePaths.has('src/pptx-raster-export.cjs'));
   assert.ok(filePaths.has('src/nano-banana.js'));
@@ -51,24 +52,21 @@ test('packed npm install exposes the packaged image CLI command', () => {
   const installRoot = mkdtempSync(join(tmpdir(), 'slides-grab-image-pack-install-'));
 
   try {
-    const output = execFileSync('npm', ['pack', '--json'], {
+    mkdirSync(packRoot, { recursive: true });
+    mkdirSync(installRoot, { recursive: true });
+
+    const output = execFileSync('npm', ['pack', '--json', '--pack-destination', packRoot], {
       cwd: process.cwd(),
       encoding: 'utf-8',
     });
     const [packInfo] = JSON.parse(output);
-    const tarballName = packInfo.filename;
-    const tarballPath = join(process.cwd(), tarballName);
-    const storedTarballPath = join(packRoot, tarballName);
+    const storedTarballPath = join(packRoot, packInfo.filename);
 
-    mkdirSync(packRoot, { recursive: true });
-    mkdirSync(installRoot, { recursive: true });
     writeFileSync(
       join(installRoot, 'package.json'),
       JSON.stringify({ name: 'slides-grab-image-pack-smoke', private: true }, null, 2),
       'utf-8',
     );
-
-    renameSync(tarballPath, storedTarballPath);
 
     execFileSync('npm', ['install', '--no-package-lock', storedTarballPath], {
       cwd: installRoot,
@@ -107,6 +105,9 @@ test('slides-grab design skill points at the bundled art-direction reference', (
   assert.match(text, /visual thesis/i);
   assert.match(text, /content plan/i);
   assert.match(text, /slide litmus check/i);
+  assert.match(text, /style-config\.json/);
+  assert.match(text, /list-styles/);
+  assert.match(text, /preview-styles/);
   assert.match(text, /slides-grab image/i);
   assert.match(text, /Nano Banana Pro/i);
   assert.match(text, /GOOGLE_API_KEY|GEMINI_API_KEY/);
@@ -142,6 +143,8 @@ test('slides-grab orchestration skill keeps image and video workflows without du
   assert.match(text, /slides-grab image/i);
   assert.match(text, /Nano Banana Pro/i);
   assert.match(text, /fetch-video|yt-dlp/i);
+  assert.match(text, /list-styles/);
+  assert.match(text, /select-style/);
   assert.match(text, /local videos/i);
   assert.equal((text.match(/When a slide needs bespoke imagery/gi) || []).length, 1);
   assert.equal((text.match(/For complex diagrams/gi) || []).length, 1);


### PR DESCRIPTION
## Summary
- bundle a cited design-style catalog derived from `corazzon/pptx-design-styles`
- add `slides-grab list-styles`, `preview-styles`, and `select-style` so users can approve a design direction before slide generation
- document the workflow in the README and packaged skills/references, and cover it with new design-style tests

## Verification
- node --test tests/design/design-styles.test.js
- npm test
- npx tsc --noEmit
- manual CLI list/preview/select flow in a temp workspace

<!-- dani:stage=implementation;job=61308a519b3645988e43e76a3738f793;issue=52 -->
