### PR TITLE
Feature/#55

### DIFF
--- a/tests/skills/installable-skills.test.js
+++ b/tests/skills/installable-skills.test.js
@@ -136,13 +136,14 @@ test('slides-grab workflow reference keeps packaged stage commands and image fal
   assert.match(text, /web search/i);
 });
 
-test('slides-grab orchestration skill keeps image and video workflows without duplicate rules', () => {
+test('slides-grab orchestration skill keeps packaged style/image/video workflows without duplicate rules', () => {
   const text = readFileSync('skills/slides-grab/SKILL.md', 'utf-8');
 
   assert.match(text, /slides-grab image/i);
   assert.match(text, /Nano Banana Pro/i);
   assert.match(text, /fetch-video|yt-dlp/i);
-  assert.match(text, /list-styles/);
+  assert.match(text, /slides-grab list-styles/);
+  assert.match(text, /slides-grab preview-styles/);
   assert.match(text, /local videos/i);
   assert.equal((text.match(/When a slide needs bespoke imagery/gi) || []).length, 1);
   assert.equal((text.match(/For complex diagrams/gi) || []).length, 1);

--- a/tests/skills/installable-skills.test.js
+++ b/tests/skills/installable-skills.test.js
@@ -112,9 +112,11 @@ test('slides-grab design skill keeps the packaged style-discovery CLI guidance',
   assert.match(text, /GOOGLE_API_KEY|GEMINI_API_KEY/);
 });
 
-test('slides-grab design rules keep packaged image and video asset commands', () => {
+test('slides-grab design rules keep packaged style, image, and video asset commands', () => {
   const text = readFileSync('skills/slides-grab-design/references/design-rules.md', 'utf-8');
 
+  assert.match(text, /slides-grab list-styles/);
+  assert.match(text, /slides-grab preview-styles/);
   assert.match(text, /slides-grab image/i);
   assert.match(text, /slides-grab fetch-video/i);
   assert.match(text, /local videos and their poster thumbnails/i);

--- a/tests/skills/installable-skills.test.js
+++ b/tests/skills/installable-skills.test.js
@@ -98,15 +98,15 @@ test('slides-grab help no longer exposes the legacy custom skill installer', () 
 
   assert.doesNotMatch(output, /\binstall-codex-skills\b/);
 });
-test('slides-grab design skill points at the bundled art-direction reference', () => {
+test('slides-grab design skill keeps the packaged style-discovery CLI guidance', () => {
   const text = readFileSync('skills/slides-grab-design/SKILL.md', 'utf-8');
 
   assert.match(text, /references\/beautiful-slide-defaults\.md/);
   assert.match(text, /visual thesis/i);
   assert.match(text, /content plan/i);
   assert.match(text, /slide litmus check/i);
-  assert.match(text, /list-styles/);
-  assert.match(text, /preview-styles/);
+  assert.match(text, /slides-grab list-styles/);
+  assert.match(text, /slides-grab preview-styles/);
   assert.match(text, /slides-grab image/i);
   assert.match(text, /Nano Banana Pro/i);
   assert.match(text, /GOOGLE_API_KEY|GEMINI_API_KEY/);


### PR DESCRIPTION
## Summary
- keep the packaged Stage 2 style guidance pinned to the full `slides-grab list-styles` / `slides-grab preview-styles` spellings
- extend that installable-skill CLI spelling guard to the top-level workflow skill regression test
- keep the follow-up scoped to the packaged docs/test contract only

## Verification
- node --test tests/skills/installable-skills.test.js
- npm test
- npm run test:e2e
- node bin/ppt-agent.js list-styles
- node bin/ppt-agent.js preview-styles
- npx tsc --noEmit
