### PR TITLE
Feature/#0

### DIFF
--- a/bin/ppt-agent.js
+++ b/bin/ppt-agent.js
@@ -270,7 +270,7 @@ program
       }
 
       console.log(`\nTotal: ${styles.length} styles`);
-      console.log('Preview: slides-grab preview-styles [--style <id>]');
+      console.log('Preview: slides-grab preview-styles');
     } catch (error) {
       reportCliError(error);
     }

--- a/tests/design/design-styles.test.js
+++ b/tests/design/design-styles.test.js
@@ -88,6 +88,8 @@ test('slides-grab list-styles shows all 35 styles', () => {
     assert.match(output, /glassmorphism/);
     assert.match(output, /modern-dark/);
     assert.match(output, /Total: 35 styles/);
+    assert.match(output, /Preview: slides-grab preview-styles\b/);
+    assert.doesNotMatch(output, /--style/);
   } finally {
     rmSync(workspace, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- remove the stale `--style` suffix from the `slides-grab list-styles` preview hint
- add a regression assertion that locks the list-styles footer to the supported `slides-grab preview-styles` command
- keep the style-discovery flow aligned across the CLI output and packaged skill guidance

## Verification
- node --test tests/design/design-styles.test.js
- node --test tests/skills/installable-skills.test.js
- npm test
- npm run test:e2e
- node bin/ppt-agent.js list-styles
- node bin/ppt-agent.js preview-styles
