### PR TITLE
Feature/#60

### DIFF
--- a/bin/ppt-agent.js
+++ b/bin/ppt-agent.js
@@ -87,8 +87,9 @@ program
   .command('build-viewer')
   .description('Build viewer.html from slide HTML files')
   .option('--slides-dir <path>', 'Slide directory', 'slides')
+  .option('--mode <mode>', 'Slide mode: presentation or card-news', 'presentation')
   .action(async (options = {}) => {
-    const args = ['--slides-dir', options.slidesDir];
+    const args = ['--slides-dir', options.slidesDir, '--mode', options.mode];
     await runCommand('scripts/build-viewer.js', args);
   });
 
@@ -98,9 +99,10 @@ program
   .description('Run structured validation on slide HTML files (Playwright-based)')
   .option('--slides-dir <path>', 'Slide directory', 'slides')
   .option('--format <format>', 'Output format: concise, json, json-full', 'concise')
+  .option('--mode <mode>', 'Slide mode: presentation or card-news', 'presentation')
   .option('--slide <file>', 'Validate only the named slide file (repeatable)', collectRepeatedOption, [])
   .action(async (options = {}) => {
-    const args = ['--slides-dir', options.slidesDir, '--format', options.format];
+    const args = ['--slides-dir', options.slidesDir, '--format', options.format, '--mode', options.mode];
     for (const slide of options.slide || []) {
       args.push('--slide', String(slide));
     }
@@ -112,9 +114,10 @@ program
   .description('Convert slide HTML files to experimental / unstable PPTX')
   .option('--slides-dir <path>', 'Slide directory', 'slides')
   .option('--output <path>', 'Output PPTX file')
+  .option('--mode <mode>', 'Slide mode: presentation or card-news', 'presentation')
   .option('--resolution <preset>', 'Raster size preset: 720p, 1080p, 1440p, 2160p, or 4k (default: 2160p)')
   .action(async (options = {}) => {
-    const args = ['--slides-dir', options.slidesDir];
+    const args = ['--slides-dir', options.slidesDir, '--mode', options.mode];
     if (options.output) {
       args.push('--output', String(options.output));
     }
@@ -130,6 +133,7 @@ program
   .option('--slides-dir <path>', 'Slide directory', 'slides')
   .option('--output <path>', 'Output PDF file')
   .option('--mode <mode>', 'PDF export mode: capture for visual fidelity, print for searchable text', 'capture')
+  .option('--slide-mode <mode>', 'Slide mode: presentation or card-news', 'presentation')
   .option('--resolution <preset>', 'Capture raster size preset: 720p, 1080p, 1440p, 2160p, or 4k (default: 2160p in capture mode)')
   .action(async (options = {}) => {
     const args = ['--slides-dir', options.slidesDir];
@@ -138,6 +142,9 @@ program
     }
     if (options.mode) {
       args.push('--mode', String(options.mode));
+    }
+    if (options.slideMode) {
+      args.push('--slide-mode', String(options.slideMode));
     }
     if (options.resolution) {
       args.push('--resolution', String(options.resolution));
@@ -165,9 +172,10 @@ program
   .helpOption('-h, --help', 'Show this help message')
   .option('--slides-dir <path>', 'Slide directory', 'slides')
   .option('--output <path>', 'Output PPTX file (default: <slides-dir>-figma.pptx)')
+  .option('--mode <mode>', 'Slide mode: presentation or card-news', 'presentation')
   .addHelpText('after', figmaHelpText)
   .action(async (options = {}) => {
-    const args = ['--slides-dir', options.slidesDir];
+    const args = ['--slides-dir', options.slidesDir, '--mode', options.mode];
     if (options.output) {
       args.push('--output', String(options.output));
     }
@@ -222,8 +230,9 @@ program
   .description('Start interactive slide editor with Codex image-based edit flow')
   .option('--port <number>', 'Server port')
   .option('--slides-dir <path>', 'Slide directory', 'slides')
+  .option('--mode <mode>', 'Slide mode: presentation or card-news', 'presentation')
   .action(async (options = {}) => {
-    const args = ['--slides-dir', options.slidesDir];
+    const args = ['--slides-dir', options.slidesDir, '--mode', options.mode];
     if (options.port) {
       args.push('--port', String(options.port));
     }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "build-viewer": "node scripts/build-viewer.js",
     "validate": "node scripts/validate-slides.js",
     "convert": "node convert.cjs",
-    "test": "node --test --test-concurrency=1 tests/design/design-styles.test.js tests/editor/editor-codex-edit.test.js tests/editor/editor-server.test.js tests/nano-banana/nano-banana.test.js tests/pdf/html2pdf.test.js tests/pdf/html2pdf.e2e.test.js tests/figma/figma-export.test.js tests/image-contract/image-contract.test.js tests/tldraw/render-tldraw.test.js tests/validation/validate-slides.test.js tests/skills/installable-skills.test.js tests/video/download-video.test.js",
+    "test": "node --test --test-concurrency=1 tests/design/design-styles.test.js tests/editor/editor-codex-edit.test.js tests/editor/editor-server.test.js tests/nano-banana/nano-banana.test.js tests/pdf/html2pdf.test.js tests/pdf/html2pdf.e2e.test.js tests/figma/figma-export.test.js tests/image-contract/image-contract.test.js tests/tldraw/render-tldraw.test.js tests/validation/validate-slides.test.js tests/viewer/build-viewer.test.js tests/skills/installable-skills.test.js tests/video/download-video.test.js",
     "test:e2e": "node --test tests/editor/editor-ui.e2e.test.js tests/editor/editor-concurrency.e2e.test.js"
   },
   "dependencies": {

--- a/scripts/build-viewer.js
+++ b/scripts/build-viewer.js
@@ -9,10 +9,19 @@
  */
 
 import { readFileSync, writeFileSync, readdirSync } from 'fs';
-import { fileURLToPath } from 'url';
+import { createRequire } from 'node:module';
 import { join, resolve } from 'path';
+import { fileURLToPath } from 'url';
 
 import { buildSlideRuntimeHtml } from '../src/image-contract.js';
+
+const require = createRequire(import.meta.url);
+const {
+  DEFAULT_SLIDE_MODE,
+  getSlideModeChoices,
+  getSlideModeConfig,
+  normalizeSlideMode,
+} = require('../src/slide-mode.cjs');
 
 const DEFAULT_SLIDES_DIR = 'slides';
 
@@ -23,6 +32,7 @@ function printUsage() {
       '',
       'Options:',
       `  --slides-dir <path>  Slide directory (default: ${DEFAULT_SLIDES_DIR})`,
+      `  --mode <mode>       Slide mode: ${getSlideModeChoices().join(', ')} (default: ${DEFAULT_SLIDE_MODE})`,
       '  -h, --help           Show this help message',
     ].join('\n'),
   );
@@ -40,6 +50,7 @@ function readOptionValue(args, index, optionName) {
 export function parseCliArgs(args) {
   const options = {
     slidesDir: DEFAULT_SLIDES_DIR,
+    mode: DEFAULT_SLIDE_MODE,
     help: false,
   };
 
@@ -62,6 +73,17 @@ export function parseCliArgs(args) {
       continue;
     }
 
+    if (arg === '--mode') {
+      options.mode = normalizeSlideMode(readOptionValue(args, i, '--mode'));
+      i += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--mode=')) {
+      options.mode = normalizeSlideMode(arg.slice('--mode='.length));
+      continue;
+    }
+
     throw new Error(`Unknown option: ${arg}`);
   }
 
@@ -70,6 +92,7 @@ export function parseCliArgs(args) {
   }
 
   options.slidesDir = options.slidesDir.trim();
+  options.mode = normalizeSlideMode(options.mode);
   return options;
 }
 
@@ -106,7 +129,9 @@ export function loadSlides(slidesDir) {
   });
 }
 
-export function buildViewerHtml(slides) {
+export function buildViewerHtml(slides, { slideMode = DEFAULT_SLIDE_MODE } = {}) {
+  const { framePt } = getSlideModeConfig(slideMode);
+
   return `<!DOCTYPE html>
 <html lang="ko">
 <head>
@@ -131,7 +156,6 @@ export function buildViewerHtml(slides) {
       flex-direction: column;
     }
 
-    /* Navigation bar */
     .nav-bar {
       height: 48px;
       background: #1a1a1a;
@@ -182,7 +206,6 @@ export function buildViewerHtml(slides) {
       padding: 6px 10px !important;
     }
 
-    /* Slide viewport */
     .slide-viewport {
       flex: 1;
       display: flex;
@@ -193,18 +216,17 @@ export function buildViewerHtml(slides) {
     }
 
     .slide-scaler {
-      width: 720pt;
-      height: 405pt;
+      width: ${framePt.width}pt;
+      height: ${framePt.height}pt;
       position: relative;
       transform-origin: center center;
     }
 
-    /* Slide frames (iframes) */
     .slide-frame {
       position: absolute;
       inset: 0;
-      width: 720pt;
-      height: 405pt;
+      width: ${framePt.width}pt;
+      height: ${framePt.height}pt;
       border: none;
       overflow: hidden;
       opacity: 0;
@@ -220,7 +242,6 @@ export function buildViewerHtml(slides) {
 </head>
 <body>
   <div class="viewer-container">
-    <!-- Navigation -->
     <div class="nav-bar">
       <button id="btn-prev" title="Previous (\\u2190)">Prev</button>
       <span class="slide-counter" id="counter">1 / ${slides.length}</span>
@@ -228,7 +249,6 @@ export function buildViewerHtml(slides) {
       <button class="btn-fullscreen" id="btn-fs" title="Fullscreen (F)">&#x26F6;</button>
     </div>
 
-    <!-- Slide viewport -->
     <div class="slide-viewport" id="viewport">
       <div class="slide-scaler" id="scaler">
 ${slides.map((s, i) => `        <iframe class="slide-frame${i === 0 ? ' active' : ''}" data-slide="${i + 1}" srcdoc="${escapeForSrcdoc(s.html)}" sandbox="allow-same-origin"></iframe>`).join('\n')}
@@ -265,7 +285,6 @@ ${slides.map((s, i) => `        <iframe class="slide-frame${i === 0 ? ' active' 
     btnNext.addEventListener('click', next);
     btnPrev.disabled = true;
 
-    // Keyboard navigation
     document.addEventListener('keydown', (e) => {
       if (e.key === 'ArrowRight' || e.key === ' ') { e.preventDefault(); next(); }
       else if (e.key === 'ArrowLeft') { e.preventDefault(); prev(); }
@@ -277,7 +296,6 @@ ${slides.map((s, i) => `        <iframe class="slide-frame${i === 0 ? ' active' 
       }
     });
 
-    // Fullscreen
     function toggleFullscreen() {
       if (!document.fullscreenElement) {
         document.documentElement.requestFullscreen().catch(() => {});
@@ -287,7 +305,6 @@ ${slides.map((s, i) => `        <iframe class="slide-frame${i === 0 ? ' active' 
     }
     document.getElementById('btn-fs').addEventListener('click', toggleFullscreen);
 
-    // Auto-scale to fit viewport (95% fit)
     function rescale() {
       const vw = viewport.clientWidth;
       const vh = viewport.clientHeight;
@@ -332,7 +349,7 @@ export function main(args = process.argv.slice(2)) {
   }
 
   console.log(`Found ${slides.length} slides`);
-  writeFileSync(output, buildViewerHtml(slides), 'utf-8');
+  writeFileSync(output, buildViewerHtml(slides, { slideMode: options.mode }), 'utf-8');
   console.log(`Built viewer: ${output}`);
   return { slidesDir, output, slides };
 }

--- a/scripts/build-viewer.js
+++ b/scripts/build-viewer.js
@@ -96,14 +96,24 @@ export function parseCliArgs(args) {
   return options;
 }
 
+function toSlideOrder(fileName) {
+  const match = fileName.match(/\d+/);
+  return match ? Number.parseInt(match[0], 10) : Number.POSITIVE_INFINITY;
+}
+
+function sortSlideFiles(a, b) {
+  const orderA = toSlideOrder(a);
+  const orderB = toSlideOrder(b);
+  if (orderA !== orderB) {
+    return orderA - orderB;
+  }
+  return a.localeCompare(b);
+}
+
 export function findSlideFiles(slidesDir) {
   return readdirSync(slidesDir)
-    .filter((file) => /^slide-\d+\.html$/i.test(file))
-    .sort((a, b) => {
-      const numA = parseInt(a.match(/\d+/)[0], 10);
-      const numB = parseInt(b.match(/\d+/)[0], 10);
-      return numA - numB || a.localeCompare(b);
-    });
+    .filter((file) => /^slide-.*\.html$/i.test(file))
+    .sort(sortSlideFiles);
 }
 
 /**

--- a/scripts/editor-server.js
+++ b/scripts/editor-server.js
@@ -3,12 +3,12 @@
 import { readdir, readFile, writeFile, mkdtemp, rm, mkdir } from 'node:fs/promises';
 import { watch as fsWatch } from 'node:fs';
 import net from 'node:net';
+import { createRequire } from 'node:module';
 import { basename, dirname, join, resolve, relative, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { tmpdir } from 'node:os';
 
 import {
-  SLIDE_SIZE,
   buildCodexEditPrompt,
   buildCodexExecArgs,
   buildClaudeExecArgs,
@@ -23,6 +23,14 @@ import {
   runEditSubprocess,
 } from '../src/editor/edit-subprocess.js';
 import { buildSlideRuntimeHtml } from '../src/image-contract.js';
+
+const require = createRequire(import.meta.url);
+const {
+  DEFAULT_SLIDE_MODE,
+  getSlideModeChoices,
+  getSlideModeConfig,
+  normalizeSlideMode,
+} = require('../src/slide-mode.cjs');
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -58,6 +66,7 @@ function printUsage() {
   process.stdout.write(`Options:\n`);
   process.stdout.write(`  --port <number>           Server port (default: ${DEFAULT_PORT})\n`);
   process.stdout.write(`  --slides-dir <path>       Slide directory (default: ${DEFAULT_SLIDES_DIR})\n`);
+  process.stdout.write(`  --mode <mode>             Slide mode: ${getSlideModeChoices().join(', ')} (default: ${DEFAULT_SLIDE_MODE})\n`);
   process.stdout.write(`  Model is selected in editor UI dropdown.\n`);
   process.stdout.write(`  -h, --help                Show this help message\n`);
 }
@@ -66,6 +75,7 @@ function parseArgs(argv) {
   const opts = {
     port: DEFAULT_PORT,
     slidesDir: DEFAULT_SLIDES_DIR,
+    mode: DEFAULT_SLIDE_MODE,
     help: false,
   };
 
@@ -98,6 +108,17 @@ function parseArgs(argv) {
       continue;
     }
 
+    if (arg === '--mode') {
+      opts.mode = normalizeSlideMode(argv[i + 1]);
+      i += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--mode=')) {
+      opts.mode = normalizeSlideMode(arg.slice('--mode='.length));
+      continue;
+    }
+
     if (arg === '--codex-model') {
       // Backward compatibility: ignore legacy CLI option.
       i += 1;
@@ -116,6 +137,7 @@ function parseArgs(argv) {
   }
 
   opts.slidesDir = opts.slidesDir.trim();
+  opts.mode = normalizeSlideMode(opts.mode);
 
   return opts;
 }
@@ -202,9 +224,9 @@ async function closeBrowser() {
   }
 }
 
-async function withScreenshotPage(callback) {
+async function withScreenshotPage(callback, screenshotSize) {
   const { browser } = await getScreenshotBrowser();
-  const { context, page } = await screenshotMod.createScreenshotPage(browser);
+  const { context, page } = await screenshotMod.createScreenshotPage(browser, screenshotSize);
   try {
     return await callback(page);
   } finally {
@@ -264,7 +286,7 @@ function sanitizeTargets(rawTargets) {
     .filter((target) => target.xpath);
 }
 
-function normalizeSelections(rawSelections) {
+function normalizeSelections(rawSelections, slideSize) {
   if (!Array.isArray(rawSelections) || rawSelections.length === 0) {
     throw new Error('At least one selection is required.');
   }
@@ -274,7 +296,7 @@ function normalizeSelections(rawSelections) {
       ? selection.bbox
       : selection;
 
-    const bbox = normalizeSelection(selectionSource, SLIDE_SIZE);
+    const bbox = normalizeSelection(selectionSource, slideSize);
     const targets = sanitizeTargets(selection?.targets);
 
     return { bbox, targets };
@@ -630,7 +652,7 @@ async function startServer(opts) {
 
     let normalizedSelections;
     try {
-      normalizedSelections = normalizeSelections(selections);
+      normalizedSelections = normalizeSelections(selections, getSlideModeConfig(opts.mode).framePx);
     } catch (error) {
       return res.status(400).json({ error: error.message });
     }
@@ -665,15 +687,15 @@ async function startServer(opts) {
           slide,
           screenshotPath,
           `http://localhost:${opts.port}/slides`,
-          { useHttp: true },
+          { useHttp: true, screenshotSize: getSlideModeConfig(opts.mode).screenshotPx },
         );
-      });
+      }, getSlideModeConfig(opts.mode).screenshotPx);
 
       const scaledBoxes = normalizedSelections.map((selection) =>
         scaleSelectionToScreenshot(
           selection.bbox,
-          SLIDE_SIZE,
-          screenshotMod.SCREENSHOT_SIZE,
+          getSlideModeConfig(opts.mode).framePx,
+          getSlideModeConfig(opts.mode).screenshotPx,
         ),
       );
 
@@ -683,6 +705,7 @@ async function startServer(opts) {
         slideFile: slide,
         slidePath: toSlidePathLabel(slidesDirectory, slide),
         userPrompt: prompt,
+        slideMode: opts.mode,
         selections: normalizedSelections,
       });
 

--- a/scripts/figma-export.js
+++ b/scripts/figma-export.js
@@ -17,6 +17,7 @@ import {
 
 const require = createRequire(import.meta.url);
 const html2pptx = require('../src/html2pptx.cjs');
+const { DEFAULT_SLIDE_MODE, getSlideModeChoices, normalizeSlideMode } = require('../src/slide-mode.cjs');
 
 const DEFAULT_SLIDES_DIR = 'slides';
 
@@ -28,6 +29,7 @@ function printUsage() {
       'Options:',
       `  --slides-dir <path>  Slide directory (default: ${DEFAULT_SLIDES_DIR})`,
       '  --output <path>      Output PPTX file (default: <slides-dir>-figma.pptx)',
+      `  --mode <mode>        Slide mode: ${getSlideModeChoices().join('|')} (default: ${DEFAULT_SLIDE_MODE})`,
       '  -h, --help           Show this help message',
       '',
       'Exports an experimental / unstable Figma Slides importable PPTX using the existing html2pptx pipeline.',
@@ -49,6 +51,7 @@ function parseArgs(args) {
   const options = {
     slidesDir: DEFAULT_SLIDES_DIR,
     output: '',
+    mode: DEFAULT_SLIDE_MODE,
     help: false,
   };
 
@@ -81,6 +84,17 @@ function parseArgs(args) {
       continue;
     }
 
+    if (arg === '--mode') {
+      options.mode = normalizeSlideMode(readOptionValue(args, i, '--mode'));
+      i += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--mode=')) {
+      options.mode = normalizeSlideMode(arg.slice('--mode='.length));
+      continue;
+    }
+
     throw new Error(`Unknown option: ${arg}`);
   }
 
@@ -89,6 +103,7 @@ function parseArgs(args) {
   }
 
   options.slidesDir = options.slidesDir.trim();
+  options.mode = normalizeSlideMode(options.mode);
   options.output = normalizeFigmaOutput(options.slidesDir, options.output);
   return options;
 }
@@ -121,7 +136,7 @@ async function main() {
   const files = getHtmlSlides(slidesDir);
 
   const pres = new PptxGenJS();
-  configureFigmaExportPresentation(pres);
+  configureFigmaExportPresentation(pres, options.mode);
 
   console.log(`Exporting ${files.length} slide(s) for Figma from ${slidesDir}`);
 

--- a/scripts/html2pdf.js
+++ b/scripts/html2pdf.js
@@ -16,6 +16,12 @@ const {
   getResolutionSize,
   normalizeResolutionPreset,
 } = require('../src/export-resolution.cjs');
+const {
+  DEFAULT_SLIDE_MODE,
+  getSlideModeChoices,
+  getSlideModeConfig,
+  normalizeSlideMode,
+} = require('../src/slide-mode.cjs');
 
 const DEFAULT_OUTPUT = 'slides.pdf';
 const DEFAULT_SLIDES_DIR = 'slides';
@@ -23,9 +29,7 @@ const DEFAULT_MODE = 'capture';
 const DEFAULT_CAPTURE_RESOLUTION = '2160p';
 const PDF_MODES = new Set(['capture', 'print']);
 const SLIDE_FILE_PATTERN = /^slide-.*\.html$/i;
-const FALLBACK_SLIDE_SIZE = { width: 960, height: 540 };
 const DEFAULT_CAPTURE_DEVICE_SCALE_FACTOR = 2;
-const TARGET_ASPECT_RATIO = 16 / 9;
 const RENDER_SETTLE_MS = 120;
 const CSS_PIXELS_PER_INCH = 96;
 const PDF_POINTS_PER_INCH = 72;
@@ -40,6 +44,7 @@ function printUsage() {
       `  --output <path>      Output PDF path (default: ${DEFAULT_OUTPUT})`,
       `  --slides-dir <path>  Slide directory (default: ${DEFAULT_SLIDES_DIR})`,
       `  --mode <mode>        PDF export mode: capture|print (default: ${DEFAULT_MODE})`,
+      `  --slide-mode <mode>  Slide mode: ${getSlideModeChoices().join('|')} (default: ${DEFAULT_SLIDE_MODE})`,
       `  --resolution <preset> Capture raster size preset: ${getResolutionChoices().join('|')}|4k (default: ${DEFAULT_CAPTURE_RESOLUTION}; ignored in print mode)`,
       '  -h, --help           Show this help message',
       '',
@@ -89,8 +94,8 @@ function cssPixelsToPdfPoints(value) {
   return Math.round((normalizeDimension(value, 0) * PDF_POINTS_PER_INCH) / CSS_PIXELS_PER_INCH);
 }
 
-async function normalizeCaptureRasterSize(pngBytes, resolution = '') {
-  const targetSize = getResolutionSize(resolution);
+async function normalizeCaptureRasterSize(pngBytes, resolution = '', slideMode = DEFAULT_SLIDE_MODE) {
+  const targetSize = getResolutionSize(resolution, slideMode);
   if (!targetSize) {
     return pngBytes;
   }
@@ -140,6 +145,7 @@ export function parseCliArgs(args) {
     output: DEFAULT_OUTPUT,
     slidesDir: DEFAULT_SLIDES_DIR,
     mode: DEFAULT_MODE,
+    slideMode: DEFAULT_SLIDE_MODE,
     resolution: DEFAULT_CAPTURE_RESOLUTION,
     help: false,
   };
@@ -185,6 +191,17 @@ export function parseCliArgs(args) {
       continue;
     }
 
+    if (arg === '--slide-mode') {
+      options.slideMode = normalizeSlideMode(readOptionValue(args, i, '--slide-mode'), { optionName: '--slide-mode' });
+      i += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--slide-mode=')) {
+      options.slideMode = normalizeSlideMode(arg.slice('--slide-mode='.length), { optionName: '--slide-mode' });
+      continue;
+    }
+
     if (arg === '--resolution') {
       options.resolution = normalizeResolutionPreset(readOptionValue(args, i, '--resolution'));
       i += 1;
@@ -209,6 +226,7 @@ export function parseCliArgs(args) {
   options.output = options.output.trim();
   options.slidesDir = options.slidesDir.trim();
   options.mode = normalizeMode(options.mode);
+  options.slideMode = normalizeSlideMode(options.slideMode, { optionName: '--slide-mode' });
   options.resolution = normalizeResolutionPreset(options.resolution);
   if (options.mode === 'print') {
     options.resolution = '';
@@ -226,9 +244,10 @@ export async function findSlideFiles(slidesDir = resolve(process.cwd(), DEFAULT_
 }
 
 export function buildPdfOptions(widthPx, heightPx) {
+  const fallbackSize = getSlideModeConfig(DEFAULT_SLIDE_MODE).framePx;
   return {
-    width: `${normalizeDimension(widthPx, FALLBACK_SLIDE_SIZE.width)}px`,
-    height: `${normalizeDimension(heightPx, FALLBACK_SLIDE_SIZE.height)}px`,
+    width: `${normalizeDimension(widthPx, fallbackSize.width)}px`,
+    height: `${normalizeDimension(heightPx, fallbackSize.height)}px`,
     printBackground: true,
     pageRanges: '1',
     margin: { top: '0px', right: '0px', bottom: '0px', left: '0px' },
@@ -236,22 +255,25 @@ export function buildPdfOptions(widthPx, heightPx) {
   };
 }
 
-export function buildPageOptions(mode = DEFAULT_MODE, resolution = '') {
-  const targetResolution = normalizeMode(mode) === 'capture' ? getResolutionSize(resolution) : null;
+export function buildPageOptions(mode = DEFAULT_MODE, resolution = '', slideMode = DEFAULT_SLIDE_MODE) {
+  const { framePx } = getSlideModeConfig(slideMode);
+  const targetResolution = normalizeMode(mode) === 'capture' ? getResolutionSize(resolution, slideMode) : null;
   return {
     viewport: {
-      width: FALLBACK_SLIDE_SIZE.width,
-      height: FALLBACK_SLIDE_SIZE.height,
+      width: framePx.width,
+      height: framePx.height,
     },
     deviceScaleFactor: normalizeMode(mode) === 'capture'
       ? targetResolution
-        ? targetResolution.height / FALLBACK_SLIDE_SIZE.height
+        ? targetResolution.height / framePx.height
         : DEFAULT_CAPTURE_DEVICE_SCALE_FACTOR
       : 1,
   };
 }
 
-function chooseSlideFrame(metrics) {
+function chooseSlideFrame(metrics, slideMode = DEFAULT_SLIDE_MODE) {
+  const { framePx } = getSlideModeConfig(slideMode);
+  const targetAspectRatio = framePx.width / framePx.height;
   const viewportArea = Math.max(1, metrics.viewport.width * metrics.viewport.height);
   const bodyArea = Math.max(1, metrics.body.width * metrics.body.height);
   const bodyScrollArea = Math.max(1, metrics.body.scrollWidth * metrics.body.scrollHeight);
@@ -269,7 +291,7 @@ function chooseSlideFrame(metrics) {
     .map((candidate) => ({
       ...candidate,
       area: candidate.width * candidate.height,
-      aspectDelta: Math.abs(candidate.width / candidate.height - TARGET_ASPECT_RATIO),
+      aspectDelta: Math.abs(candidate.width / candidate.height - targetAspectRatio),
       coverage: (candidate.width * candidate.height) / viewportArea,
     }))
     .sort((left, right) => right.area - left.area);
@@ -359,7 +381,7 @@ export async function waitForSlideRenderReady(page, options = {}) {
   }, { settleMs, runReadySignal: shouldRunReadySignal });
 }
 
-export async function detectSlideFrame(page) {
+export async function detectSlideFrame(page, slideMode = DEFAULT_SLIDE_MODE) {
   const metrics = await page.evaluate(() => {
     function toBox(element) {
       const rect = element.getBoundingClientRect();
@@ -398,12 +420,13 @@ export async function detectSlideFrame(page) {
     };
   });
 
-  const frame = chooseSlideFrame(metrics);
+  const frame = chooseSlideFrame(metrics, slideMode);
+  const fallbackSize = getSlideModeConfig(slideMode).framePx;
   return {
     x: normalizeDimension(frame.x, 0),
     y: normalizeDimension(frame.y, 0),
-    width: normalizeDimension(frame.width, FALLBACK_SLIDE_SIZE.width),
-    height: normalizeDimension(frame.height, FALLBACK_SLIDE_SIZE.height),
+    width: normalizeDimension(frame.width, fallbackSize.width),
+    height: normalizeDimension(frame.height, fallbackSize.height),
     candidateIndex: Number.isInteger(frame.candidateIndex) ? frame.candidateIndex : null,
     source: frame.source,
   };
@@ -641,20 +664,22 @@ export async function renderSlideToPdf(page, slideFile, slidesDir, options = {})
   const slidePath = join(slidesDir, slideFile);
   const slideUrl = pathToFileURL(slidePath).href;
   const mode = normalizeMode(options.mode ?? DEFAULT_MODE);
+  const slideMode = normalizeSlideMode(options.slideMode ?? DEFAULT_SLIDE_MODE, { optionName: '--slide-mode' });
   const captureResolution = mode === 'capture' ? normalizeResolutionPreset(options.resolution ?? '') : '';
 
   await page.goto(slideUrl, { waitUntil: 'load' });
   await waitForSlideRenderReady(page, options);
 
-  const slideFrame = await detectSlideFrame(page);
+  const slideFrame = await detectSlideFrame(page, slideMode);
   const normalizedSlideFrame = await isolateSlideFrame(page, slideFrame);
   await normalizeBodyToSlideFrame(page, normalizedSlideFrame);
   await waitForSlideRenderReady(page, { ...options, runReadySignal: false });
 
   if (mode === 'capture') {
+    const fallbackSize = getSlideModeConfig(slideMode).framePx;
     const viewportSize = {
-      width: normalizeDimension(normalizedSlideFrame.width, FALLBACK_SLIDE_SIZE.width),
-      height: normalizeDimension(normalizedSlideFrame.height, FALLBACK_SLIDE_SIZE.height),
+      width: normalizeDimension(normalizedSlideFrame.width, fallbackSize.width),
+      height: normalizeDimension(normalizedSlideFrame.height, fallbackSize.height),
     };
     await page.setViewportSize(viewportSize);
     await waitForSlideRenderReady(page, { ...options, runReadySignal: false });
@@ -679,9 +704,10 @@ export async function renderSlideToPdf(page, slideFile, slidesDir, options = {})
         height: viewportSize.height,
       },
     });
-    const normalizedPngBytes = await normalizeCaptureRasterSize(pngBytes, captureResolution);
+    const normalizedPngBytes = await normalizeCaptureRasterSize(pngBytes, captureResolution, slideMode);
     return {
       mode,
+      slideMode,
       width: normalizedSlideFrame.width,
       height: normalizedSlideFrame.height,
       pngBytes: normalizedPngBytes,
@@ -692,6 +718,7 @@ export async function renderSlideToPdf(page, slideFile, slidesDir, options = {})
 
   return {
     mode,
+    slideMode,
     width: normalizedSlideFrame.width,
     height: normalizedSlideFrame.height,
     pdfBytes: await page.pdf(buildPdfOptions(normalizedSlideFrame.width, normalizedSlideFrame.height)),
@@ -740,14 +767,14 @@ async function main() {
   }
 
   const slidesDir = resolve(process.cwd(), options.slidesDir);
-  await ensureSlidesPassValidation(slidesDir, { exportLabel: 'PDF export' });
+  await ensureSlidesPassValidation(slidesDir, { exportLabel: 'PDF export', slideMode: options.slideMode });
   const slideFiles = await findSlideFiles(slidesDir);
   if (slideFiles.length === 0) {
     throw new Error(`No slide-*.html files found in: ${slidesDir}`);
   }
 
   const browser = await chromium.launch({ headless: true });
-  const page = await browser.newPage(buildPageOptions(options.mode, options.resolution));
+  const page = await browser.newPage(buildPageOptions(options.mode, options.resolution, options.slideMode));
   const diagnostics = createSlideDiagnostics();
   diagnostics.attach(page);
   const renderedSlides = [];
@@ -758,6 +785,7 @@ async function main() {
       try {
         const slideResult = await renderSlideToPdf(page, slideFile, slidesDir, {
           mode: options.mode,
+          slideMode: options.slideMode,
           resolution: options.resolution,
         });
         renderedSlides.push(slideResult);

--- a/scripts/html2pptx.js
+++ b/scripts/html2pptx.js
@@ -10,6 +10,7 @@ import { ensureOutputDirectory, SLIDE_FILE_PATTERN, sortFigmaSlideFiles } from '
 
 const require = createRequire(import.meta.url);
 const html2pptx = require('../src/html2pptx.cjs');
+const { DEFAULT_SLIDE_MODE, getSlideModeChoices, getSlideModeConfig, normalizeSlideMode } = require('../src/slide-mode.cjs');
 
 const DEFAULT_SLIDES_DIR = 'slides';
 const DEFAULT_OUTPUT = 'output.pptx';
@@ -22,6 +23,7 @@ function printUsage() {
       'Options:',
       `  --slides-dir <path>  Slide directory (default: ${DEFAULT_SLIDES_DIR})`,
       `  --output <path>      Output PPTX file (default: ${DEFAULT_OUTPUT})`,
+      `  --mode <mode>        Slide mode: ${getSlideModeChoices().join('|')} (default: ${DEFAULT_SLIDE_MODE})`,
       '  -h, --help           Show this help message',
       '',
       'Experimental / unstable PPTX export. Treat output as best-effort only.',
@@ -42,6 +44,7 @@ function parseArgs(args) {
   const options = {
     slidesDir: DEFAULT_SLIDES_DIR,
     output: DEFAULT_OUTPUT,
+    mode: DEFAULT_SLIDE_MODE,
     help: false,
   };
 
@@ -74,6 +77,17 @@ function parseArgs(args) {
       continue;
     }
 
+    if (arg === '--mode') {
+      options.mode = normalizeSlideMode(readOptionValue(args, i, '--mode'));
+      i += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--mode=')) {
+      options.mode = normalizeSlideMode(arg.slice('--mode='.length));
+      continue;
+    }
+
     throw new Error(`Unknown option: ${arg}`);
   }
 
@@ -87,6 +101,7 @@ function parseArgs(args) {
 
   options.slidesDir = options.slidesDir.trim();
   options.output = options.output.trim();
+  options.mode = normalizeSlideMode(options.mode);
   return options;
 }
 
@@ -118,7 +133,13 @@ async function main() {
   const files = getHtmlSlides(slidesDir);
 
   const pres = new PptxGenJS();
-  pres.layout = 'LAYOUT_WIDE';
+  const { pptxSizeIn } = getSlideModeConfig(options.mode);
+  pres.defineLayout({
+    name: 'SLIDES_GRAB_HTML2PPTX',
+    width: pptxSizeIn.width,
+    height: pptxSizeIn.height,
+  });
+  pres.layout = 'SLIDES_GRAB_HTML2PPTX';
 
   for (const file of files) {
     await html2pptx(resolve(slidesDir, file), pres);

--- a/scripts/validate-slides.js
+++ b/scripts/validate-slides.js
@@ -2,6 +2,7 @@
 
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
 import { chromium } from 'playwright';
 
 import {
@@ -19,6 +20,9 @@ import {
   scanSlides,
   selectSlideFiles,
 } from '../src/validation/core.js';
+
+const require = createRequire(import.meta.url);
+const { DEFAULT_SLIDE_MODE } = require('../src/slide-mode.cjs');
 
 export {
   DEFAULT_SLIDES_DIR,
@@ -160,7 +164,7 @@ function peekValidateFormat(args = []) {
   return DEFAULT_VALIDATE_FORMAT;
 }
 
-export async function validateSlides(slidesDir, { selectedSlides = [] } = {}) {
+export async function validateSlides(slidesDir, { mode = DEFAULT_SLIDE_MODE, selectedSlides = [] } = {}) {
   const slideFiles = selectSlideFiles(await findSlideFiles(slidesDir), selectedSlides, slidesDir);
   if (slideFiles.length === 0) {
     throw new Error(`No slide-*.html files found in: ${slidesDir}`);
@@ -171,11 +175,24 @@ export async function validateSlides(slidesDir, { selectedSlides = [] } = {}) {
   const page = await context.newPage();
 
   try {
-    const slides = await scanSlides(page, slidesDir, slideFiles);
-    return createValidationResult(slides);
+    const slides = await scanSlides(page, slidesDir, slideFiles, mode);
+    return createValidationResult(slides, mode);
   } finally {
     await browser.close();
   }
+}
+
+function peekValidateMode(args = []) {
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === '--mode') {
+      return args[i + 1] || DEFAULT_SLIDE_MODE;
+    }
+    if (arg.startsWith('--mode=')) {
+      return arg.slice('--mode='.length) || DEFAULT_SLIDE_MODE;
+    }
+  }
+  return DEFAULT_SLIDE_MODE;
 }
 
 export async function main(args = process.argv.slice(2)) {
@@ -186,7 +203,7 @@ export async function main(args = process.argv.slice(2)) {
   }
 
   const slidesDir = resolve(process.cwd(), options.slidesDir);
-  const result = await validateSlides(slidesDir, { selectedSlides: options.slides });
+  const result = await validateSlides(slidesDir, { mode: options.mode, selectedSlides: options.slides });
   process.stdout.write(formatValidationResult(result, options.format));
   if (result.summary.failedSlides > 0) {
     process.exitCode = 1;
@@ -197,7 +214,7 @@ const isMain = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(imp
 
 if (isMain) {
   main().catch((error) => {
-    const failure = createValidationFailure(error);
+    const failure = createValidationFailure(error, peekValidateMode(process.argv.slice(2)));
     process.stdout.write(formatValidationResult(failure, peekValidateFormat(process.argv.slice(2))));
     process.exit(1);
   });

--- a/skills/slides-grab-card-news/SKILL.md
+++ b/skills/slides-grab-card-news/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: slides-grab-card-news
+description: Generate square Instagram-style card news by reusing the slides-grab workflow with card-news mode enabled.
+metadata:
+  short-description: Square card-news workflow on top of slides-grab
+---
+
+# slides-grab Card News Skill (Codex)
+
+Use this when the user wants card news instead of a widescreen presentation.
+
+## Goal
+Reuse the existing slides-grab plan/design/export workflow, but generate **square** outputs optimized for Instagram posts.
+
+## Workflow
+1. Reuse the normal outline process from `slides-grab-plan`.
+2. During design and review, keep every card at **720pt x 720pt** and run:
+   - `slides-grab validate --slides-dir <path> --mode card-news`
+   - `slides-grab build-viewer --slides-dir <path> --mode card-news`
+   - `slides-grab edit --slides-dir <path> --mode card-news`
+3. During export, reuse the normal export policy with card-news sizing:
+   - `slides-grab convert --slides-dir <path> --mode card-news --output <name>.pptx`
+   - `slides-grab pdf --slides-dir <path> --slide-mode card-news --output <name>.pdf`
+   - `slides-grab figma --slides-dir <path> --mode card-news --output <name>-figma.pptx`
+4. Remind the user that PPTX/Figma exports remain experimental / unstable.
+
+## Rules
+- Optimize layouts for square Instagram-style card news, not 16:9 slides.
+- Reuse existing design, viewer, editor, and export policy wherever possible.
+- Do **not** implement SNS/Instagram publishing automation.
+- Use the packaged CLI and bundled skills only.

--- a/src/editor/codex-edit.js
+++ b/src/editor/codex-edit.js
@@ -1,11 +1,21 @@
 import { readFileSync } from 'node:fs';
 import { mkdir } from 'node:fs/promises';
+import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 import sharp from 'sharp';
 
 import { getPackageRoot } from '../resolve.js';
 
+const require = createRequire(import.meta.url);
+const {
+  DEFAULT_SLIDE_MODE,
+  getSlideModeConfig,
+} = require('../slide-mode.cjs');
+
 export const SLIDE_SIZE = { width: 960, height: 540 };
+export function getSlideSize(slideMode = DEFAULT_SLIDE_MODE) {
+  return getSlideModeConfig(slideMode).framePx;
+}
 
 const PPT_DESIGN_SKILL_PATH = join(getPackageRoot(), 'skills', 'slides-grab-design', 'SKILL.md');
 const EDITOR_CODEX_PROMPT_PATH = join(dirname(new URL(import.meta.url).pathname), 'editor-codex-prompt.md');
@@ -331,11 +341,12 @@ export function getDetailedDesignSkillPrompt() {
   ].filter(Boolean).join('\n\n');
 }
 
-export function buildCodexEditPrompt({ slideFile, slidePath, userPrompt, selections = [] }) {
+export function buildCodexEditPrompt({ slideFile, slidePath, userPrompt, slideMode = DEFAULT_SLIDE_MODE, selections = [] }) {
   const sanitizedPrompt = typeof userPrompt === 'string' ? userPrompt.trim() : '';
   if (!sanitizedPrompt) {
     throw new Error('Prompt must be a non-empty string.');
   }
+  const { coordinateSpaceLabel, sizeLabel } = getSlideModeConfig(slideMode);
 
   const normalizedSlidePath = typeof slidePath === 'string' && slidePath.trim() !== ''
     ? slidePath.trim()
@@ -357,7 +368,12 @@ export function buildCodexEditPrompt({ slideFile, slidePath, userPrompt, selecti
     ];
   });
 
-  const editorPrompt = getEditorPptDesignSkillPrompt();
+  const editorPrompt = getEditorPptDesignSkillPrompt()
+    .replaceAll('720pt x 405pt', sizeLabel)
+    .replace(
+      'Run `slides-grab validate --slides-dir <path>` after editing.',
+      `Run \`slides-grab validate --slides-dir <path>${slideMode === DEFAULT_SLIDE_MODE ? '' : ` --mode ${slideMode}`}\` after editing.`,
+    );
   const editorPromptLines = editorPrompt
     ? [
         'Slide edit rules (follow strictly):',
@@ -373,13 +389,13 @@ export function buildCodexEditPrompt({ slideFile, slidePath, userPrompt, selecti
     'User edit request (this is the primary objective — follow it faithfully):',
     sanitizedPrompt,
     '',
-    'Selected regions on slide (960x540 coordinate space):',
+    `Selected regions on slide (${coordinateSpaceLabel} coordinate space):`,
     ...selectionLines,
     'Rules:',
     '- Edit only the requested slide HTML file among slide-*.html files.',
     '- Do not modify any other slide HTML files unless explicitly requested.',
     '- Keep existing structure/content unless the request requires a change.',
-    '- Keep slide dimensions at 720pt x 405pt.',
+    `- Keep slide dimensions at ${sizeLabel}.`,
     '- Keep text in semantic tags (<p>, <h1>-<h6>, <ul>, <ol>, <li>).',
     '- You may add or update supporting files required for the requested slide, including local images and videos under <slides-dir>/assets/ and tldraw source/export files used to generate those assets.',
     '- When the request needs bespoke imagery, prefer `slides-grab image --prompt "<prompt>" --slides-dir <path>` so Nano Banana Pro saves the asset under <slides-dir>/assets/.',

--- a/src/editor/editor-codex-prompt.md
+++ b/src/editor/editor-codex-prompt.md
@@ -15,7 +15,7 @@ The user's edit request is the primary objective. All rules below exist to suppo
 5. Return after applying the change.
 
 ## Slide Rules
-- Keep slide size 720pt x 405pt.
+- Keep slide size appropriate for the current mode (`720pt x 405pt` for presentation, `720pt x 720pt` for card-news).
 - Keep semantic text tags (`p`, `h1-h6`, `ul`, `ol`, `li`).
 - Never place text directly in `<div>` or `<span>`.
 - Always include `#` prefix in CSS colors.

--- a/src/editor/screenshot.js
+++ b/src/editor/screenshot.js
@@ -17,8 +17,8 @@ export async function createScreenshotBrowser() {
  * Create a fresh screenshot page/context from an existing browser.
  * Caller must close the returned context.
  */
-export async function createScreenshotPage(browser) {
-  const context = await browser.newContext({ viewport: SCREENSHOT_SIZE });
+export async function createScreenshotPage(browser, screenshotSize = SCREENSHOT_SIZE) {
+  const context = await browser.newContext({ viewport: screenshotSize });
   const page = await context.newPage();
   return { context, page };
 }
@@ -34,6 +34,7 @@ export async function createScreenshotPage(browser) {
  * @param {boolean} [options.useHttp]       – if true, slidesDir is treated as a base URL
  */
 export async function captureSlideScreenshot(page, slideFile, screenshotPath, slidesDir, options = {}) {
+  const screenshotSize = options.screenshotSize || SCREENSHOT_SIZE;
   const slideUrl = options.useHttp
     ? `${slidesDir}/${slideFile}`
     : pathToFileURL(join(slidesDir, slideFile)).href;
@@ -64,7 +65,7 @@ export async function captureSlideScreenshot(page, slideFile, screenshotPath, sl
     const scale = Math.min(width / sourceWidth, height / sourceHeight);
 
     bodyStyle.transform = `scale(${scale})`;
-  }, SCREENSHOT_SIZE);
+  }, screenshotSize);
 
   await page.screenshot({
     path: screenshotPath,

--- a/src/export-resolution.cjs
+++ b/src/export-resolution.cjs
@@ -1,8 +1,13 @@
-const RESOLUTION_PRESETS = Object.freeze({
-  '720p': { width: 1280, height: 720 },
-  '1080p': { width: 1920, height: 1080 },
-  '1440p': { width: 2560, height: 1440 },
-  '2160p': { width: 3840, height: 2160 },
+const {
+  DEFAULT_SLIDE_MODE,
+  getSlideModeConfig,
+} = require('./slide-mode.cjs');
+
+const RESOLUTION_HEIGHTS = Object.freeze({
+  '720p': 720,
+  '1080p': 1080,
+  '1440p': 1440,
+  '2160p': 2160,
 });
 
 const RESOLUTION_ALIASES = Object.freeze({
@@ -11,7 +16,7 @@ const RESOLUTION_ALIASES = Object.freeze({
 });
 
 function getResolutionChoices() {
-  return Object.keys(RESOLUTION_PRESETS);
+  return Object.keys(RESOLUTION_HEIGHTS);
 }
 
 function normalizeResolutionPreset(value, options = {}) {
@@ -33,25 +38,30 @@ function normalizeResolutionPreset(value, options = {}) {
   }
 
   const normalized = RESOLUTION_ALIASES[trimmed] || trimmed;
-  if (!RESOLUTION_PRESETS[normalized]) {
+  if (!RESOLUTION_HEIGHTS[normalized]) {
     throw new Error(`Unknown resolution "${value}". Expected one of: ${getResolutionChoices().join(', ')}, 4k`);
   }
 
   return normalized;
 }
 
-function getResolutionSize(value) {
+function getResolutionSize(value, slideMode = DEFAULT_SLIDE_MODE) {
   const normalized = normalizeResolutionPreset(value);
   if (!normalized) {
     return null;
   }
 
-  const preset = RESOLUTION_PRESETS[normalized];
-  return { width: preset.width, height: preset.height };
+  const height = RESOLUTION_HEIGHTS[normalized];
+  const { framePx } = getSlideModeConfig(slideMode);
+  const aspectRatio = framePx.width / framePx.height;
+  return {
+    width: Math.round(height * aspectRatio),
+    height,
+  };
 }
 
 module.exports = {
-  RESOLUTION_PRESETS,
+  RESOLUTION_PRESETS: RESOLUTION_HEIGHTS,
   getResolutionChoices,
   getResolutionSize,
   normalizeResolutionPreset,

--- a/src/figma.js
+++ b/src/figma.js
@@ -1,5 +1,12 @@
+import { createRequire } from 'node:module';
 import { mkdir } from 'node:fs/promises';
 import { basename, dirname, extname, join, resolve } from 'node:path';
+
+const require = createRequire(import.meta.url);
+const {
+  DEFAULT_SLIDE_MODE,
+  getSlideModeConfig,
+} = require('./slide-mode.cjs');
 
 export const DEFAULT_FIGMA_SUFFIX = '-figma.pptx';
 export const SLIDE_FILE_PATTERN = /^slide-.*\.html$/i;
@@ -36,11 +43,12 @@ export function getFigmaManualImportInstructions() {
   return 'Figma Slides -> Import -> select the generated .pptx file.';
 }
 
-export function configureFigmaExportPresentation(pres) {
+export function configureFigmaExportPresentation(pres, slideMode = DEFAULT_SLIDE_MODE) {
+  const { figmaSizeIn } = getSlideModeConfig(slideMode);
   pres.defineLayout({
     name: FIGMA_EXPORT_LAYOUT_NAME,
-    width: SLIDE_WIDTH_INCHES,
-    height: SLIDE_HEIGHT_INCHES,
+    width: figmaSizeIn.width,
+    height: figmaSizeIn.height,
   });
   pres.layout = FIGMA_EXPORT_LAYOUT_NAME;
   return pres;

--- a/src/pptx-raster-export.cjs
+++ b/src/pptx-raster-export.cjs
@@ -21,6 +21,7 @@ const DEFAULT_OUTPUT = 'output.pptx';
 const DEFAULT_RESOLUTION = '2160p';
 const DEFAULT_CAPTURE_DEVICE_SCALE_FACTOR = 2;
 const TARGET_RASTER_DPI = 150;
+const SLIDE_FILE_PATTERN = /^slide-.*\.html$/i;
 
 function normalizeDimension(value, fallback) {
   if (!Number.isFinite(value) || value <= 0) {
@@ -54,6 +55,36 @@ function getTargetRasterSize(resolution = '', slideMode = DEFAULT_SLIDE_MODE) {
     width: Math.round(pptxSizeIn.width * TARGET_RASTER_DPI),
     height: Math.round(pptxSizeIn.height * TARGET_RASTER_DPI),
   };
+}
+
+function toSlideOrder(fileName) {
+  const match = fileName.match(/\d+/);
+  return match ? Number.parseInt(match[0], 10) : Number.POSITIVE_INFINITY;
+}
+
+function sortSlideFiles(a, b) {
+  const orderA = toSlideOrder(a);
+  const orderB = toSlideOrder(b);
+  if (orderA !== orderB) {
+    return orderA - orderB;
+  }
+  return a.localeCompare(b);
+}
+
+function getHtmlSlides(slidesDir) {
+  if (!fs.existsSync(slidesDir)) {
+    throw new Error(`Slides directory not found: ${slidesDir}`);
+  }
+
+  const files = fs.readdirSync(slidesDir)
+    .filter((fileName) => SLIDE_FILE_PATTERN.test(fileName))
+    .sort(sortSlideFiles);
+
+  if (files.length === 0) {
+    throw new Error(`No slide-*.html files found in ${slidesDir}`);
+  }
+
+  return files;
 }
 
 function printUsage() {
@@ -224,9 +255,7 @@ async function main(argv = process.argv.slice(2)) {
   const slidesDir = path.resolve(process.cwd(), options.slidesDir);
   const { ensureSlidesPassValidation } = await import('../scripts/validate-slides.js');
   await ensureSlidesPassValidation(slidesDir, { exportLabel: 'PPTX export', slideMode: options.mode });
-  const files = fs.readdirSync(slidesDir)
-    .filter((fileName) => fileName.endsWith('.html'))
-    .sort();
+  const files = getHtmlSlides(slidesDir);
 
   console.log(`Converting ${files.length} slides...`);
 
@@ -260,6 +289,7 @@ async function main(argv = process.argv.slice(2)) {
 
 module.exports = {
   buildPageOptions,
+  getHtmlSlides,
   getTargetRasterSize,
   main,
   parseArgs,

--- a/src/pptx-raster-export.cjs
+++ b/src/pptx-raster-export.cjs
@@ -9,14 +9,18 @@ const {
   getResolutionSize,
   normalizeResolutionPreset,
 } = require('./export-resolution.cjs');
+const {
+  DEFAULT_SLIDE_MODE,
+  getSlideModeChoices,
+  getSlideModeConfig,
+  normalizeSlideMode,
+} = require('./slide-mode.cjs');
 
 const DEFAULT_SLIDES_DIR = 'slides';
 const DEFAULT_OUTPUT = 'output.pptx';
 const DEFAULT_RESOLUTION = '2160p';
-const DEFAULT_CAPTURE_VIEWPORT = { width: 960, height: 540 };
 const DEFAULT_CAPTURE_DEVICE_SCALE_FACTOR = 2;
 const TARGET_RASTER_DPI = 150;
-const TARGET_SLIDE_SIZE_IN = { width: 13.33, height: 7.5 };
 
 function normalizeDimension(value, fallback) {
   if (!Number.isFinite(value) || value <= 0) {
@@ -25,28 +29,30 @@ function normalizeDimension(value, fallback) {
   return Math.max(1, Math.round(value));
 }
 
-function buildPageOptions(resolution = '') {
-  const targetResolution = getResolutionSize(resolution);
+function buildPageOptions(resolution = '', slideMode = DEFAULT_SLIDE_MODE) {
+  const { framePx } = getSlideModeConfig(slideMode);
+  const targetResolution = getResolutionSize(resolution, slideMode);
   return {
     viewport: {
-      width: DEFAULT_CAPTURE_VIEWPORT.width,
-      height: DEFAULT_CAPTURE_VIEWPORT.height,
+      width: framePx.width,
+      height: framePx.height,
     },
     deviceScaleFactor: targetResolution
-      ? targetResolution.height / DEFAULT_CAPTURE_VIEWPORT.height
+      ? targetResolution.height / framePx.height
       : DEFAULT_CAPTURE_DEVICE_SCALE_FACTOR,
   };
 }
 
-function getTargetRasterSize(resolution = '') {
-  const targetResolution = getResolutionSize(resolution);
+function getTargetRasterSize(resolution = '', slideMode = DEFAULT_SLIDE_MODE) {
+  const targetResolution = getResolutionSize(resolution, slideMode);
   if (targetResolution) {
     return targetResolution;
   }
 
+  const { pptxSizeIn } = getSlideModeConfig(slideMode);
   return {
-    width: Math.round(TARGET_SLIDE_SIZE_IN.width * TARGET_RASTER_DPI),
-    height: Math.round(TARGET_SLIDE_SIZE_IN.height * TARGET_RASTER_DPI),
+    width: Math.round(pptxSizeIn.width * TARGET_RASTER_DPI),
+    height: Math.round(pptxSizeIn.height * TARGET_RASTER_DPI),
   };
 }
 
@@ -58,6 +64,7 @@ function printUsage() {
       'Options:',
       `  --slides-dir <path>  Slide directory (default: ${DEFAULT_SLIDES_DIR})`,
       `  --output <path>      Output pptx path (default: ${DEFAULT_OUTPUT})`,
+      `  --mode <mode>        Slide mode: ${getSlideModeChoices().join('|')} (default: ${DEFAULT_SLIDE_MODE})`,
       `  --resolution <preset> Raster size preset: ${getResolutionChoices().join('|')}|4k (default: ${DEFAULT_RESOLUTION})`,
       '  -h, --help           Show this help message',
     ].join('\n'),
@@ -77,6 +84,7 @@ function parseArgs(args) {
   const options = {
     slidesDir: DEFAULT_SLIDES_DIR,
     output: DEFAULT_OUTPUT,
+    mode: DEFAULT_SLIDE_MODE,
     resolution: DEFAULT_RESOLUTION,
     help: false,
   };
@@ -110,6 +118,17 @@ function parseArgs(args) {
       continue;
     }
 
+    if (arg === '--mode') {
+      options.mode = normalizeSlideMode(readOptionValue(args, i, '--mode'));
+      i += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--mode=')) {
+      options.mode = normalizeSlideMode(arg.slice('--mode='.length));
+      continue;
+    }
+
     if (arg === '--resolution') {
       options.resolution = normalizeResolutionPreset(readOptionValue(args, i, '--resolution'));
       i += 1;
@@ -134,14 +153,17 @@ function parseArgs(args) {
 
   options.slidesDir = options.slidesDir.trim();
   options.output = options.output.trim();
+  options.mode = normalizeSlideMode(options.mode);
   options.resolution = normalizeResolutionPreset(options.resolution);
   return options;
 }
 
 async function convertSlide(htmlFile, pres, browser, options = {}) {
   const filePath = path.isAbsolute(htmlFile) ? htmlFile : path.join(process.cwd(), htmlFile);
+  const slideMode = normalizeSlideMode(options.mode || DEFAULT_SLIDE_MODE);
+  const fallbackSize = getSlideModeConfig(slideMode).framePx;
 
-  const page = await browser.newPage(buildPageOptions(options.resolution));
+  const page = await browser.newPage(buildPageOptions(options.resolution, slideMode));
   await page.goto(`file://${filePath}`);
 
   const bodyDimensions = await page.evaluate(() => {
@@ -154,14 +176,14 @@ async function convertSlide(htmlFile, pres, browser, options = {}) {
   });
 
   await page.setViewportSize({
-    width: normalizeDimension(bodyDimensions.width, DEFAULT_CAPTURE_VIEWPORT.width),
-    height: normalizeDimension(bodyDimensions.height, DEFAULT_CAPTURE_VIEWPORT.height),
+    width: normalizeDimension(bodyDimensions.width, fallbackSize.width),
+    height: normalizeDimension(bodyDimensions.height, fallbackSize.height),
   });
 
   const screenshot = await page.screenshot({ type: 'png' });
   await page.close();
 
-  const targetSize = getTargetRasterSize(options.resolution);
+  const targetSize = getTargetRasterSize(options.resolution, slideMode);
 
   const resized = await sharp(screenshot)
     .resize(targetSize.width, targetSize.height, { fit: 'fill' })
@@ -191,11 +213,17 @@ async function main(argv = process.argv.slice(2)) {
   }
 
   const pres = new PptxGenJS();
-  pres.layout = 'LAYOUT_WIDE';
+  const { pptxSizeIn } = getSlideModeConfig(options.mode);
+  pres.defineLayout({
+    name: 'SLIDES_GRAB_DYNAMIC',
+    width: pptxSizeIn.width,
+    height: pptxSizeIn.height,
+  });
+  pres.layout = 'SLIDES_GRAB_DYNAMIC';
 
   const slidesDir = path.resolve(process.cwd(), options.slidesDir);
   const { ensureSlidesPassValidation } = await import('../scripts/validate-slides.js');
-  await ensureSlidesPassValidation(slidesDir, { exportLabel: 'PPTX export' });
+  await ensureSlidesPassValidation(slidesDir, { exportLabel: 'PPTX export', slideMode: options.mode });
   const files = fs.readdirSync(slidesDir)
     .filter((fileName) => fileName.endsWith('.html'))
     .sort();
@@ -209,7 +237,7 @@ async function main(argv = process.argv.slice(2)) {
     const filePath = path.join(slidesDir, file);
     console.log(`  Processing: ${file}`);
     try {
-      const tmpPath = await convertSlide(filePath, pres, browser, { resolution: options.resolution });
+      const tmpPath = await convertSlide(filePath, pres, browser, { mode: options.mode, resolution: options.resolution });
       tmpFiles.push(tmpPath);
       console.log(`    ✓ ${file} done`);
     } catch (error) {

--- a/src/slide-mode.cjs
+++ b/src/slide-mode.cjs
@@ -1,0 +1,72 @@
+const DEFAULT_SLIDE_MODE = 'presentation';
+const PT_TO_PX = 96 / 72;
+
+const SLIDE_MODES = Object.freeze({
+  presentation: Object.freeze({
+    name: 'presentation',
+    framePt: Object.freeze({ width: 720, height: 405 }),
+    framePx: Object.freeze({ width: 720 * PT_TO_PX, height: 405 * PT_TO_PX }),
+    screenshotPx: Object.freeze({ width: 1600, height: 900 }),
+    pptxSizeIn: Object.freeze({ width: 13.33, height: 7.5 }),
+    figmaSizeIn: Object.freeze({ width: 10, height: 5.625 }),
+    sizeLabel: '720pt x 405pt',
+    coordinateSpaceLabel: '960x540',
+    aspectRatioLabel: '16:9',
+  }),
+  'card-news': Object.freeze({
+    name: 'card-news',
+    framePt: Object.freeze({ width: 720, height: 720 }),
+    framePx: Object.freeze({ width: 720 * PT_TO_PX, height: 720 * PT_TO_PX }),
+    screenshotPx: Object.freeze({ width: 1600, height: 1600 }),
+    pptxSizeIn: Object.freeze({ width: 10, height: 10 }),
+    figmaSizeIn: Object.freeze({ width: 10, height: 10 }),
+    sizeLabel: '720pt x 720pt',
+    coordinateSpaceLabel: '960x960',
+    aspectRatioLabel: '1:1',
+  }),
+});
+
+function getSlideModeChoices() {
+  return Object.keys(SLIDE_MODES);
+}
+
+function normalizeSlideMode(value, options = {}) {
+  const {
+    allowEmpty = false,
+    optionName = '--mode',
+  } = options;
+
+  if (typeof value !== 'string') {
+    if (allowEmpty) {
+      return '';
+    }
+    throw new Error(`${optionName} must be one of: ${getSlideModeChoices().join(', ')}`);
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (normalized === '') {
+    if (allowEmpty) {
+      return '';
+    }
+    throw new Error(`${optionName} must be one of: ${getSlideModeChoices().join(', ')}`);
+  }
+
+  if (!SLIDE_MODES[normalized]) {
+    throw new Error(`Unknown ${optionName} value: ${value}. Expected one of: ${getSlideModeChoices().join(', ')}`);
+  }
+
+  return normalized;
+}
+
+function getSlideModeConfig(value = DEFAULT_SLIDE_MODE) {
+  return SLIDE_MODES[normalizeSlideMode(value, { optionName: '--mode' })];
+}
+
+module.exports = {
+  DEFAULT_SLIDE_MODE,
+  PT_TO_PX,
+  SLIDE_MODES,
+  getSlideModeChoices,
+  getSlideModeConfig,
+  normalizeSlideMode,
+};

--- a/src/validation/cli.js
+++ b/src/validation/cli.js
@@ -1,3 +1,12 @@
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+  DEFAULT_SLIDE_MODE,
+  getSlideModeChoices,
+  normalizeSlideMode,
+} = require('../slide-mode.cjs');
+
 export const DEFAULT_SLIDES_DIR = 'slides';
 export const DEFAULT_VALIDATE_FORMAT = 'concise';
 export const VALIDATE_FORMATS = ['concise', 'json', 'json-full'];
@@ -14,6 +23,7 @@ export function parseValidateCliArgs(args) {
   const options = {
     slidesDir: DEFAULT_SLIDES_DIR,
     format: DEFAULT_VALIDATE_FORMAT,
+    mode: DEFAULT_SLIDE_MODE,
     help: false,
     slides: [],
   };
@@ -48,6 +58,17 @@ export function parseValidateCliArgs(args) {
       continue;
     }
 
+    if (arg === '--mode') {
+      options.mode = normalizeSlideMode(readOptionValue(args, i, '--mode'));
+      i += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--mode=')) {
+      options.mode = normalizeSlideMode(arg.slice('--mode='.length));
+      continue;
+    }
+
     if (arg === '--slide') {
       options.slides.push(readOptionValue(args, i, '--slide'));
       i += 1;
@@ -72,6 +93,7 @@ export function parseValidateCliArgs(args) {
 
   options.slidesDir = options.slidesDir.trim();
   options.format = options.format.trim();
+  options.mode = normalizeSlideMode(options.mode);
 
   if (!VALIDATE_FORMATS.includes(options.format)) {
     throw new Error(`Unknown --format value: ${options.format}. Expected one of: ${VALIDATE_FORMATS.join(', ')}`);
@@ -91,6 +113,7 @@ export function getValidateUsage() {
     'Options:',
     `  --slides-dir <path>  Slide directory (default: ${DEFAULT_SLIDES_DIR})`,
     `  --format <format>   Output format: ${VALIDATE_FORMATS.join(', ')} (default: ${DEFAULT_VALIDATE_FORMAT})`,
+    `  --mode <mode>       Slide mode: ${getSlideModeChoices().join(', ')} (default: ${DEFAULT_SLIDE_MODE})`,
     '  --slide <file>      Validate only the named slide file (repeatable)',
     '  -h, --help           Show this help message',
   ].join('\n');

--- a/src/validation/core.js
+++ b/src/validation/core.js
@@ -1,4 +1,5 @@
 import { access, readdir } from 'node:fs/promises';
+import { createRequire } from 'node:module';
 import { basename, join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { chromium } from 'playwright';
@@ -9,12 +10,14 @@ import {
   resolveSlideSourcePath,
 } from '../image-contract.js';
 
-export const FRAME_PT = { width: 720, height: 405 };
-export const PT_TO_PX = 96 / 72;
-export const FRAME_PX = {
-  width: FRAME_PT.width * PT_TO_PX,
-  height: FRAME_PT.height * PT_TO_PX,
-};
+const require = createRequire(import.meta.url);
+const {
+  DEFAULT_SLIDE_MODE,
+  getSlideModeConfig,
+} = require('../slide-mode.cjs');
+
+export const FRAME_PT = getSlideModeConfig(DEFAULT_SLIDE_MODE).framePt;
+export const FRAME_PX = getSlideModeConfig(DEFAULT_SLIDE_MODE).framePx;
 export const SLIDE_FILE_PATTERN = /^slide-.*\.html$/i;
 export const TEXT_SELECTOR = 'p,h1,h2,h3,h4,h5,h6,li';
 export const TOLERANCE_PX = 0.5;
@@ -58,28 +61,30 @@ export function summarizeSlides(slides) {
   return summary;
 }
 
-export function createValidationResult(slides) {
+export function createValidationResult(slides, slideMode = DEFAULT_SLIDE_MODE) {
+  const { framePt, framePx } = getSlideModeConfig(slideMode);
   return {
     generatedAt: new Date().toISOString(),
     frame: {
-      widthPt: FRAME_PT.width,
-      heightPt: FRAME_PT.height,
-      widthPx: FRAME_PX.width,
-      heightPx: FRAME_PX.height,
+      widthPt: framePt.width,
+      heightPt: framePt.height,
+      widthPx: framePx.width,
+      heightPx: framePx.height,
     },
     slides,
     summary: summarizeSlides(slides),
   };
 }
 
-export function createValidationFailure(error) {
+export function createValidationFailure(error, slideMode = DEFAULT_SLIDE_MODE) {
+  const { framePt, framePx } = getSlideModeConfig(slideMode);
   return {
     generatedAt: new Date().toISOString(),
     frame: {
-      widthPt: FRAME_PT.width,
-      heightPt: FRAME_PT.height,
-      widthPx: FRAME_PX.width,
-      heightPx: FRAME_PX.height,
+      widthPt: framePt.width,
+      heightPt: framePt.height,
+      widthPx: framePx.width,
+      heightPx: framePx.height,
     },
     slides: [],
     summary: {
@@ -347,9 +352,10 @@ export function selectSlideFiles(slideFiles, selectedSlides = [], slidesDir = ''
   return slideFiles.filter((slide) => available.has(slide) && requested.includes(slide));
 }
 
-export async function inspectSlide(page, fileName, slidesDir) {
+export async function inspectSlide(page, fileName, slidesDir, slideMode = DEFAULT_SLIDE_MODE) {
   const slidePath = join(slidesDir, fileName);
   const slideUrl = pathToFileURL(slidePath).href;
+  const { framePx, sizeLabel } = getSlideModeConfig(slideMode);
 
   await page.goto(slideUrl, { waitUntil: 'load' });
   await page.evaluate(async () => {
@@ -359,7 +365,7 @@ export async function inspectSlide(page, fileName, slidesDir) {
   });
 
   const inspection = await page.evaluate(
-    ({ framePx, textSelector, tolerancePx }) => {
+    ({ framePx, sizeLabel, textSelector, tolerancePx }) => {
       const skipTags = new Set(['SCRIPT', 'STYLE', 'META', 'LINK', 'HEAD', 'TITLE', 'NOSCRIPT']);
       const critical = [];
       const warning = [];
@@ -552,7 +558,7 @@ export async function inspectSlide(page, fileName, slidesDir) {
         if (outsideFrame) {
           critical.push({
             code: 'overflow-outside-frame',
-            message: 'Element exceeds the 720pt x 405pt slide frame.',
+            message: `Element exceeds the ${sizeLabel} slide frame.`,
             element: elementPath(element),
             bbox: normalizeRect(rect),
             frame: normalizeRect(frameRect),
@@ -663,7 +669,8 @@ export async function inspectSlide(page, fileName, slidesDir) {
       };
     },
     {
-      framePx: FRAME_PX,
+      framePx,
+      sizeLabel,
       textSelector: TEXT_SELECTOR,
       tolerancePx: TOLERANCE_PX,
     },
@@ -696,12 +703,12 @@ export async function inspectSlide(page, fileName, slidesDir) {
   };
 }
 
-export async function scanSlides(page, slidesDir, slideFiles) {
+export async function scanSlides(page, slidesDir, slideFiles, slideMode = DEFAULT_SLIDE_MODE) {
   const slides = [];
 
   for (const slideFile of slideFiles) {
     try {
-      const result = await inspectSlide(page, slideFile, slidesDir);
+      const result = await inspectSlide(page, slideFile, slidesDir, slideMode);
       slides.push(result);
     } catch (error) {
       slides.push({
@@ -740,7 +747,10 @@ export function formatValidationFailureForExport(result, exportLabel = 'Export')
   }
 
   const suffix = findings.length > 0 ? `\n${findings.join('\n')}` : '';
-  return `${exportLabel} blocked by slide validation. Run \`slides-grab validate --slides-dir <path>\` for full diagnostics.${suffix}`;
+  const modeHint = result.slideMode && result.slideMode !== DEFAULT_SLIDE_MODE
+    ? ` --mode ${result.slideMode}`
+    : '';
+  return `${exportLabel} blocked by slide validation. Run \`slides-grab validate --slides-dir <path>${modeHint}\` for full diagnostics.${suffix}`;
 }
 
 const EXPORT_BLOCKING_IMAGE_CONTRACT_CODES = new Set([
@@ -799,6 +809,7 @@ export async function ensureSlidesPassValidation(
   slidesDir,
   {
     exportLabel = 'Export',
+    slideMode = DEFAULT_SLIDE_MODE,
     shouldBlockIssue = isBlockingImageContractIssue,
   } = {},
 ) {
@@ -812,8 +823,11 @@ export async function ensureSlidesPassValidation(
   const page = await context.newPage();
 
   try {
-    const slides = await scanSlides(page, slidesDir, slideFiles);
-    const result = createValidationResult(slides);
+    const slides = await scanSlides(page, slidesDir, slideFiles, slideMode);
+    const result = {
+      ...createValidationResult(slides, slideMode),
+      slideMode,
+    };
     const blockingResult = filterExportBlockingSlides(result, shouldBlockIssue);
     if (blockingResult.summary.failedSlides > 0) {
       throw new Error(formatValidationFailureForExport(blockingResult, exportLabel));

--- a/tests/editor/editor-codex-edit.test.js
+++ b/tests/editor/editor-codex-edit.test.js
@@ -80,7 +80,7 @@ test('buildCodexEditPrompt includes user prompt, bbox, and XPath targets', () =>
   assert.match(prompt, /Region 1/);
   assert.match(prompt, /Slide edit rules \(follow strictly\):/);
   assert.match(prompt, /primary objective/i);
-  assert.match(prompt, /Keep slide size 720pt x 405pt\./);
+  assert.match(prompt, /Keep slide size appropriate for the current mode/);
   assert.match(prompt, /slides-grab image/i);
   assert.match(prompt, /GOOGLE_API_KEY|GEMINI_API_KEY/);
   assert.match(prompt, /Edit only the requested slide HTML file among slide-\*\.html files\./);
@@ -183,4 +183,17 @@ test('buildEditTimeoutMessage describes terminated editor runs', () => {
     buildEditTimeoutMessage({ engineLabel: 'Codex', timeoutMs: 200 }),
     'Codex edit timed out after 200ms and was terminated.',
   );
+});
+
+
+test('buildCodexEditPrompt switches sizing guidance for card-news mode', () => {
+  const prompt = buildCodexEditPrompt({
+    slideFile: 'slide-03.html',
+    userPrompt: 'Tighten this card-news cover.',
+    slideMode: 'card-news',
+    selections: [{ bbox: { x: 40, y: 48, width: 320, height: 320 }, targets: [] }],
+  });
+
+  assert.match(prompt, /Selected regions on slide \(960x960 coordinate space\):/);
+  assert.match(prompt, /Keep slide dimensions at 720pt x 720pt\./);
 });

--- a/tests/editor/editor-server.test.js
+++ b/tests/editor/editor-server.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { mkdtemp, mkdir, writeFile, rm, chmod } from 'node:fs/promises';
 import os from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -13,24 +13,45 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function createWorkspace() {
+async function createWorkspace({ slideHtml } = {}) {
   const workspace = await mkdtemp(join(os.tmpdir(), 'editor-server-test-'));
   const slidesDir = join(workspace, 'slides');
   await mkdir(slidesDir, { recursive: true });
-  await writeFile(join(slidesDir, 'slide-01.html'), '<!doctype html><html><body><div><h1>Test</h1><p>Slide</p></div></body></html>', 'utf8');
+  await writeFile(
+    join(slidesDir, 'slide-01.html'),
+    slideHtml || '<!doctype html><html><body><div><h1>Test</h1><p>Slide</p></div></body></html>',
+    'utf8',
+  );
   return workspace;
 }
 
-function spawnEditorServer(workspace, port) {
+async function writeMockCli(workspace, fileName) {
+  const mockPath = join(workspace, fileName);
+  const script = `#!/usr/bin/env node
+const prompt = process.argv[process.argv.length - 1] || '';
+process.stdout.write(prompt);
+process.exit(0);
+`;
+  await writeFile(mockPath, script, 'utf8');
+  await chmod(mockPath, 0o755);
+  return mockPath;
+}
+
+function spawnEditorServer(workspace, port, { args = [], env = {} } = {}) {
   const output = { value: '' };
-  const child = spawn(process.execPath, [join(REPO_ROOT, 'scripts', 'editor-server.js'), '--port', String(port)], {
-    cwd: workspace,
-    env: {
-      ...process.env,
-      PPT_AGENT_PACKAGE_ROOT: REPO_ROOT,
+  const child = spawn(
+    process.execPath,
+    [join(REPO_ROOT, 'scripts', 'editor-server.js'), '--port', String(port), ...args],
+    {
+      cwd: workspace,
+      env: {
+        ...process.env,
+        PPT_AGENT_PACKAGE_ROOT: REPO_ROOT,
+        ...env,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
     },
-    stdio: ['ignore', 'pipe', 'pipe'],
-  });
+  );
 
   child.stdout.on('data', (chunk) => {
     output.value += chunk.toString();
@@ -115,6 +136,80 @@ test('refuses to open a second editor when another slides-grab editor already ow
     assert.equal(res.ok, true, `first editor should still be serving slides\n${first.output.value}`);
   } finally {
     await stopChild(first.child);
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test('card-news editor mode passes square sizing guidance into Codex apply runs', async () => {
+  const workspace = await createWorkspace({
+    slideHtml: `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      html, body { margin: 0; width: 960px; height: 960px; overflow: hidden; }
+      body { font-family: sans-serif; }
+      .frame { width: 960px; height: 960px; padding: 48px; box-sizing: border-box; }
+    </style>
+  </head>
+  <body>
+    <div class="frame">
+      <h1>Square headline</h1>
+      <p>Card-news body copy.</p>
+    </div>
+  </body>
+</html>`,
+  });
+  const mockCodex = await writeMockCli(workspace, 'mock-codex.js');
+  const port = await getAvailablePort();
+  const server = spawnEditorServer(workspace, port, {
+    args: ['--mode', 'card-news'],
+    env: {
+      PPT_AGENT_CODEX_BIN: mockCodex,
+    },
+  });
+
+  try {
+    await waitForServerReady(port, server.child, server.output);
+
+    const applyRes = await fetch(`http://localhost:${port}/api/apply`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        slide: 'slide-01.html',
+        prompt: 'Tighten the square cover composition.',
+        selections: [
+          {
+            x: 80,
+            y: 120,
+            width: 420,
+            height: 360,
+            targets: [
+              {
+                xpath: '/html/body/div[1]/h1[1]',
+                tag: 'h1',
+                text: 'Square headline',
+              },
+            ],
+          },
+        ],
+      }),
+    });
+
+    const applyBody = await applyRes.json();
+    assert.equal(applyRes.status, 200, JSON.stringify(applyBody));
+    assert.equal(applyBody.success, true);
+    assert.equal(applyBody.selectionsCount, 1);
+
+    const logRes = await fetch(`http://localhost:${port}/api/runs/${applyBody.runId}/log`);
+    assert.equal(logRes.status, 200);
+    const log = await logRes.text();
+
+    assert.match(log, /Selected regions on slide \(960x960 coordinate space\):/);
+    assert.match(log, /Keep slide dimensions at 720pt x 720pt\./);
+    assert.match(log, /slides-grab validate --slides-dir <path> --mode card-news/);
+  } finally {
+    await stopChild(server.child);
     await rm(workspace, { recursive: true, force: true });
   }
 });

--- a/tests/figma/convert.test.js
+++ b/tests/figma/convert.test.js
@@ -9,15 +9,19 @@ test('parseArgs applies default slides dir and output', () => {
   assert.deepEqual(parseArgs([]), {
     slidesDir: 'slides',
     output: 'output.pptx',
+    mode: 'presentation',
     resolution: '2160p',
     help: false,
   });
 });
 
 test('parseArgs reads resolution presets and normalizes aliases', () => {
+  assert.equal(parseArgs(['--mode', 'card-news']).mode, 'card-news');
   assert.equal(parseArgs(['--resolution', '1440p']).resolution, '1440p');
   assert.equal(parseArgs(['--resolution=4k']).resolution, '2160p');
+  assert.throws(() => parseArgs(['--mode']), /missing value/i);
   assert.throws(() => parseArgs(['--resolution']), /missing value/i);
+  assert.throws(() => parseArgs(['--mode', 'story']), /unknown --mode value/i);
   assert.throws(() => parseArgs(['--resolution', 'retina']), /unknown resolution/i);
 });
 
@@ -45,6 +49,19 @@ test('getTargetRasterSize preserves the legacy 150 DPI slide target by default',
 test('getTargetRasterSize returns preset raster dimensions when requested', () => {
   assert.deepEqual(getTargetRasterSize('1440p'), {
     width: 2560,
+    height: 1440,
+  });
+});
+
+
+test('buildPageOptions and raster size switch to square outputs for card-news mode', () => {
+  assert.deepEqual(buildPageOptions('2160p', 'card-news'), {
+    viewport: { width: 960, height: 960 },
+    deviceScaleFactor: 2160 / 960,
+  });
+
+  assert.deepEqual(getTargetRasterSize('1440p', 'card-news'), {
+    width: 1440,
     height: 1440,
   });
 });

--- a/tests/figma/convert.test.js
+++ b/tests/figma/convert.test.js
@@ -1,9 +1,12 @@
 import assert from 'node:assert/strict';
+import os from 'node:os';
+import path from 'node:path';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import test from 'node:test';
 
 const require = createRequire(import.meta.url);
-const { buildPageOptions, getTargetRasterSize, parseArgs } = require('../../src/pptx-raster-export.cjs');
+const { buildPageOptions, getHtmlSlides, getTargetRasterSize, parseArgs } = require('../../src/pptx-raster-export.cjs');
 
 test('parseArgs applies default slides dir and output', () => {
   assert.deepEqual(parseArgs([]), {
@@ -53,6 +56,22 @@ test('getTargetRasterSize returns preset raster dimensions when requested', () =
   });
 });
 
+test('getHtmlSlides only returns slide-*.html deck files', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'pptx-raster-export-'));
+  try {
+    await Promise.all([
+      writeFile(path.join(tempDir, 'slide-10.html'), ''),
+      writeFile(path.join(tempDir, 'slide-2.html'), ''),
+      writeFile(path.join(tempDir, 'slide-01.html'), ''),
+      writeFile(path.join(tempDir, 'viewer.html'), ''),
+      writeFile(path.join(tempDir, 'notes.html'), ''),
+    ]);
+
+    assert.deepEqual(getHtmlSlides(tempDir), ['slide-01.html', 'slide-2.html', 'slide-10.html']);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
 
 test('buildPageOptions and raster size switch to square outputs for card-news mode', () => {
   assert.deepEqual(buildPageOptions('2160p', 'card-news'), {

--- a/tests/image-contract/image-contract.test.js
+++ b/tests/image-contract/image-contract.test.js
@@ -232,6 +232,7 @@ test('validator CLI args still parse slides-dir', () => {
   assert.deepEqual(parseValidateCliArgs(['--slides-dir', 'decks/demo']), {
     slidesDir: 'decks/demo',
     format: 'concise',
+    mode: 'presentation',
     help: false,
     slides: [],
   });

--- a/tests/pdf/html2pdf.test.js
+++ b/tests/pdf/html2pdf.test.js
@@ -25,6 +25,7 @@ test('parseCliArgs applies defaults for output, slides dir, mode, and help', () 
     output: 'slides.pdf',
     slidesDir: 'slides',
     mode: 'capture',
+    slideMode: 'presentation',
     resolution: '2160p',
     help: false,
   });
@@ -37,6 +38,7 @@ test('parseCliArgs reads output, slides dir, mode, and resolution options', () =
   assert.equal(parseCliArgs(['--slides-dir=slides-q1']).slidesDir, 'slides-q1');
   assert.equal(parseCliArgs(['--mode', 'print']).mode, 'print');
   assert.equal(parseCliArgs(['--mode=CAPTURE']).mode, 'capture');
+  assert.equal(parseCliArgs(['--slide-mode', 'card-news']).slideMode, 'card-news');
   assert.equal(parseCliArgs(['--resolution', '2160p']).resolution, '2160p');
   assert.equal(parseCliArgs(['--resolution=4k']).resolution, '2160p');
 });
@@ -51,8 +53,10 @@ test('parseCliArgs rejects missing and invalid option values', () => {
   assert.throws(() => parseCliArgs(['--output']), /missing value/i);
   assert.throws(() => parseCliArgs(['--slides-dir']), /missing value/i);
   assert.throws(() => parseCliArgs(['--mode']), /missing value/i);
+  assert.throws(() => parseCliArgs(['--slide-mode']), /missing value/i);
   assert.throws(() => parseCliArgs(['--resolution']), /missing value/i);
   assert.throws(() => parseCliArgs(['--mode', 'vector']), /unknown pdf mode/i);
+  assert.throws(() => parseCliArgs(['--slide-mode', 'story']), /unknown --slide-mode value/i);
   assert.throws(() => parseCliArgs(['--resolution', 'retina']), /unknown resolution/i);
 });
 
@@ -112,6 +116,13 @@ test('buildPageOptions honors requested capture resolution presets', () => {
   assert.deepEqual(buildPageOptions('print', '2160p'), {
     viewport: { width: 960, height: 540 },
     deviceScaleFactor: 1,
+  });
+});
+
+test('buildPageOptions switches to square viewport for card-news capture mode', () => {
+  assert.deepEqual(buildPageOptions('capture', '1440p', 'card-news'), {
+    viewport: { width: 960, height: 960 },
+    deviceScaleFactor: 1440 / 960,
   });
 });
 

--- a/tests/skills/installable-skills.test.js
+++ b/tests/skills/installable-skills.test.js
@@ -10,6 +10,7 @@ const INSTALLABLE_SKILLS = [
   'skills/slides-grab-plan/SKILL.md',
   'skills/slides-grab-design/SKILL.md',
   'skills/slides-grab-export/SKILL.md',
+  'skills/slides-grab-card-news/SKILL.md',
 ];
 
 test('installable skills use packaged commands and avoid .claude runtime paths', () => {
@@ -40,6 +41,7 @@ test('npm pack includes bundled skill references for installable skills', () => 
   assert.ok(filePaths.has('skills/slides-grab-export/references/html2pptx.md'));
   assert.ok(filePaths.has('skills/slides-grab-export/references/ooxml.md'));
   assert.ok(filePaths.has('skills/slides-grab/references/presentation-workflow-reference.md'));
+  assert.ok(filePaths.has('skills/slides-grab-card-news/SKILL.md'));
   assert.ok(filePaths.has('templates/design-styles/README.md'));
   assert.ok(filePaths.has('scripts/generate-image.js'));
   assert.ok(filePaths.has('src/pptx-raster-export.cjs'));
@@ -153,4 +155,15 @@ test('slides-grab design rules advertise both packaged image and video asset com
 
   assert.match(text, /slides-grab image --prompt/i);
   assert.match(text, /slides-grab fetch-video/i);
+});
+
+
+test('slides-grab card-news skill documents square Instagram workflow via packaged commands', () => {
+  const text = readFileSync('skills/slides-grab-card-news/SKILL.md', 'utf-8');
+
+  assert.match(text, /Instagram/i);
+  assert.match(text, /card-news/i);
+  assert.match(text, /--mode card-news|--slide-mode card-news/);
+  assert.match(text, /slides-grab validate/i);
+  assert.match(text, /slides-grab build-viewer/i);
 });

--- a/tests/validation/validate-slides.test.js
+++ b/tests/validation/validate-slides.test.js
@@ -228,3 +228,27 @@ test('slides-grab lint aliases validate output and exit code', () => {
   assert.equal(payload.summary.failedSlides, 2);
   assert.equal(payload.summary.errors, 3);
 });
+
+test('slides-grab mode-aware help covers card-news CLI entrypoints', () => {
+  const helpCommands = [
+    ['build-viewer', /Slide mode: presentation or card-news/],
+    ['validate', /Slide mode: presentation or card-news/],
+    ['convert', /Slide mode: presentation or card-news/],
+    ['pdf', /Slide mode: presentation or card-news/],
+    ['figma', /Slide mode: presentation or card-news/],
+    ['edit', /Slide mode: presentation or card-news/],
+  ];
+
+  for (const [subcommand, expectedModeLine] of helpCommands) {
+    const command = spawnSync(process.execPath, ['bin/ppt-agent.js', subcommand, '--help'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    });
+
+    assert.equal(command.status, 0, `${subcommand} --help should exit cleanly`);
+    assert.equal(command.stderr, '');
+    assert.match(command.stdout, new RegExp(`slides-grab ${subcommand}`));
+    assert.match(command.stdout, expectedModeLine);
+    assert.match(command.stdout, /card-news/);
+  }
+});

--- a/tests/validation/validate-slides.test.js
+++ b/tests/validation/validate-slides.test.js
@@ -21,6 +21,7 @@ test('parseValidateCliArgs applies defaults and reads --slides-dir', () => {
   assert.deepEqual(parseValidateCliArgs([]), {
     slidesDir: DEFAULT_SLIDES_DIR,
     format: DEFAULT_VALIDATE_FORMAT,
+    mode: 'presentation',
     help: false,
     slides: [],
   });
@@ -28,12 +29,15 @@ test('parseValidateCliArgs applies defaults and reads --slides-dir', () => {
   assert.equal(parseValidateCliArgs(['--slides-dir', 'decks/demo']).slidesDir, 'decks/demo');
   assert.equal(parseValidateCliArgs(['--slides-dir=slides-q1']).slidesDir, 'slides-q1');
   assert.equal(parseValidateCliArgs(['--format', 'json']).format, 'json');
+  assert.equal(parseValidateCliArgs(['--mode', 'card-news']).mode, 'card-news');
   assert.deepEqual(
     parseValidateCliArgs(['--slide', 'slide-02.html', '--slide=slide-03.html']).slides,
     ['slide-02.html', 'slide-03.html'],
   );
   assert.throws(() => parseValidateCliArgs(['--slides-dir']), /missing value/i);
+  assert.throws(() => parseValidateCliArgs(['--mode']), /missing value/i);
   assert.throws(() => parseValidateCliArgs(['--format', 'xml']), /unknown --format value/i);
+  assert.throws(() => parseValidateCliArgs(['--mode', 'story']), /unknown --mode value/i);
 });
 
 test('findSlideFiles sorts slide fixtures deterministically', async () => {
@@ -103,6 +107,28 @@ test('validate CLI defaults to concise output', () => {
   assert.match(command.stdout, /^slide-04\.html:warning\[sibling-overlap\]/m);
   assert.match(command.stdout, /^summary: 4 slide\(s\) checked, 2 passed, 2 failed, 3 error\(s\), 1 warning\(s\)$/m);
   assert.doesNotMatch(command.stdout, /^\s*\{/);
+});
+
+test('validate CLI json-full reports square frame metadata in card-news mode', () => {
+  const command = spawnSync(
+    process.execPath,
+    ['scripts/validate-slides.js', '--slides-dir', fixtureDeckDir, '--mode', 'card-news', '--format', 'json-full'],
+    {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    },
+  );
+
+  assert.equal(command.status, 1);
+  assert.equal(command.stderr, '');
+
+  const payload = JSON.parse(command.stdout);
+  assert.deepEqual(payload.frame, {
+    widthPt: 720,
+    heightPt: 720,
+    widthPx: 960,
+    heightPx: 960,
+  });
 });
 
 test('validate CLI json-full preserves legacy detailed result shape', () => {

--- a/tests/viewer/build-viewer.test.js
+++ b/tests/viewer/build-viewer.test.js
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 import test from 'node:test';
 
-import { buildViewerHtml, parseCliArgs } from '../../scripts/build-viewer.js';
+import { buildViewerHtml, findSlideFiles, parseCliArgs } from '../../scripts/build-viewer.js';
 
 test('build-viewer CLI supports card-news mode', () => {
   assert.deepEqual(parseCliArgs([]), { slidesDir: 'slides', mode: 'presentation', help: false });
@@ -15,4 +18,28 @@ test('buildViewerHtml uses square frame dimensions for card-news mode', () => {
 
   assert.match(html, /width: 720pt;/);
   assert.match(html, /height: 720pt;/);
+});
+
+test('findSlideFiles honors the slide-*.html deck contract and ignores viewer artifacts', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'build-viewer-slides-'));
+
+  try {
+    await Promise.all([
+      writeFile(path.join(tempDir, 'slide-10.html'), ''),
+      writeFile(path.join(tempDir, 'slide-2.html'), ''),
+      writeFile(path.join(tempDir, 'slide-alpha.html'), ''),
+      writeFile(path.join(tempDir, 'Slide-03.HTML'), ''),
+      writeFile(path.join(tempDir, 'viewer.html'), ''),
+      writeFile(path.join(tempDir, 'notes.html'), ''),
+    ]);
+
+    assert.deepEqual(findSlideFiles(tempDir), [
+      'slide-2.html',
+      'Slide-03.HTML',
+      'slide-10.html',
+      'slide-alpha.html',
+    ]);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
 });

--- a/tests/viewer/build-viewer.test.js
+++ b/tests/viewer/build-viewer.test.js
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { buildViewerHtml, parseCliArgs } from '../../scripts/build-viewer.js';
+
+test('build-viewer CLI supports card-news mode', () => {
+  assert.deepEqual(parseCliArgs([]), { slidesDir: 'slides', mode: 'presentation', help: false });
+  assert.equal(parseCliArgs(['--mode', 'card-news']).mode, 'card-news');
+  assert.throws(() => parseCliArgs(['--mode']), /missing value/i);
+  assert.throws(() => parseCliArgs(['--mode', 'story']), /unknown --mode value/i);
+});
+
+test('buildViewerHtml uses square frame dimensions for card-news mode', () => {
+  const html = buildViewerHtml([{ file: 'slide-01.html', html: '<!doctype html><html><body></body></html>' }], { slideMode: 'card-news' });
+
+  assert.match(html, /width: 720pt;/);
+  assert.match(html, /height: 720pt;/);
+});


### PR DESCRIPTION
## Summary
- add a shared card-news slide mode for square 720pt x 720pt / 960x960 workflows
- thread the new mode through validate, viewer, editor, PDF/PPTX/Figma export, and CLI entrypoints
- add a packaged `slides-grab-card-news` skill plus regression coverage for mode-aware behavior

## Verification
- `npm test`
- `npx tsc --noEmit`
- manual `slides-grab validate --mode card-news`
- manual `slides-grab build-viewer --mode card-news`

<!-- dani:stage=implementation;job=0b795ac741694cfdbf77803f5e56bb5a;issue=60 -->
