### PR TITLE
Feature/#69

### DIFF
--- a/src/editor/codex-edit.js
+++ b/src/editor/codex-edit.js
@@ -450,7 +450,7 @@ export function buildCodexExecArgs({ prompt, imagePath, model }) {
   return args;
 }
 
-export const CLAUDE_MODELS = ['claude-opus-4-6', 'claude-sonnet-4-6'];
+export const CLAUDE_MODELS = ['claude-opus-4-7', 'claude-sonnet-4-6'];
 
 export function isClaudeModel(model) {
   return typeof model === 'string' && CLAUDE_MODELS.includes(model.trim());

--- a/src/editor/js/editor-state.js
+++ b/src/editor/js/editor-state.js
@@ -15,7 +15,7 @@ export const POPOVER_TEXT = 'text';
 export const POPOVER_TEXT_COLOR = 'text-color';
 export const POPOVER_BG_COLOR = 'bg-color';
 export const POPOVER_SIZE = 'size';
-export const DEFAULT_MODELS = ['gpt-5.4', 'gpt-5.3-codex', 'gpt-5.3-codex-spark', 'claude-opus-4-6', 'claude-sonnet-4-6'];
+export const DEFAULT_MODELS = ['gpt-5.4', 'gpt-5.3-codex', 'gpt-5.3-codex-spark', 'claude-opus-4-7', 'claude-sonnet-4-6'];
 export const DIRECT_TEXT_TAGS = new Set(['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li']);
 export const NON_SELECTABLE_TAGS = new Set(['html', 'head', 'body', 'script', 'style', 'link', 'meta', 'noscript']);
 

--- a/tests/editor/editor-codex-edit.test.js
+++ b/tests/editor/editor-codex-edit.test.js
@@ -3,10 +3,13 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import test from 'node:test';
 
 import {
+  buildClaudeExecArgs,
   buildCodexEditPrompt,
   buildCodexExecArgs,
+  CLAUDE_MODELS,
   getDetailedDesignSkillPrompt,
   getPptDesignSkillPrompt,
+  isClaudeModel,
   normalizeSelection,
   scaleSelectionToScreenshot,
 } from '../../src/editor/codex-edit.js';
@@ -15,6 +18,7 @@ import {
   DEFAULT_EDIT_TIMEOUT_MS,
   parseEditTimeoutMs,
 } from '../../src/editor/edit-subprocess.js';
+import { DEFAULT_MODELS } from '../../src/editor/js/editor-state.js';
 
 const DETAILED_DESIGN_RULES_URL = new URL(
   '../../skills/slides-grab-design/references/detailed-design-rules.md',
@@ -241,4 +245,82 @@ test('buildCodexEditPrompt switches sizing guidance for card-news mode', () => {
 
   assert.match(prompt, /Selected regions on slide \(960x960 coordinate space\):/);
   assert.match(prompt, /Keep slide dimensions at 720pt x 720pt\./);
+});
+
+test('CLAUDE_MODELS exposes claude-opus-4-7 as the bbox-editor Opus option (issue #69)', () => {
+  assert.ok(
+    CLAUDE_MODELS.includes('claude-opus-4-7'),
+    `CLAUDE_MODELS should include 'claude-opus-4-7' so the editor dropdown can route edits to Opus 4.7. Got: ${JSON.stringify(CLAUDE_MODELS)}`,
+  );
+});
+
+test('CLAUDE_MODELS drops the superseded claude-opus-4-6 identifier (issue #69)', () => {
+  assert.ok(
+    !CLAUDE_MODELS.includes('claude-opus-4-6'),
+    `CLAUDE_MODELS should no longer include 'claude-opus-4-6' after the Opus 4.7 upgrade. Got: ${JSON.stringify(CLAUDE_MODELS)}`,
+  );
+});
+
+test('CLAUDE_MODELS still exposes claude-sonnet-4-6 (there is no Sonnet 4.7 yet)', () => {
+  assert.ok(
+    CLAUDE_MODELS.includes('claude-sonnet-4-6'),
+    `CLAUDE_MODELS should still include 'claude-sonnet-4-6' because Sonnet 4.7 does not exist. Got: ${JSON.stringify(CLAUDE_MODELS)}`,
+  );
+});
+
+test('isClaudeModel recognizes claude-opus-4-7 after the upgrade', () => {
+  assert.equal(isClaudeModel('claude-opus-4-7'), true);
+  assert.equal(isClaudeModel('  claude-opus-4-7  '), true);
+});
+
+test('isClaudeModel rejects the dropped claude-opus-4-6 identifier', () => {
+  assert.equal(isClaudeModel('claude-opus-4-6'), false);
+});
+
+test('buildClaudeExecArgs forwards claude-opus-4-7 to the claude CLI --model flag', () => {
+  const args = buildClaudeExecArgs({
+    prompt: 'Edit slide',
+    imagePath: '/tmp/slide-annotated.png',
+    model: 'claude-opus-4-7',
+  });
+
+  assert.deepEqual(args, [
+    '-p',
+    '--dangerously-skip-permissions',
+    '--model',
+    'claude-opus-4-7',
+    '--max-turns',
+    '30',
+    '--verbose',
+    'First, read the annotated screenshot at "/tmp/slide-annotated.png" to see the visual context of the bbox regions highlighted on the slide.\n\nEdit slide',
+  ]);
+});
+
+test('DEFAULT_MODELS exposes claude-opus-4-7 as the Claude Opus fallback (issue #69)', () => {
+  assert.ok(
+    DEFAULT_MODELS.includes('claude-opus-4-7'),
+    `DEFAULT_MODELS should include 'claude-opus-4-7' so the editor UI dropdown falls back to Opus 4.7 when /api/models is unreachable. Got: ${JSON.stringify(DEFAULT_MODELS)}`,
+  );
+});
+
+test('DEFAULT_MODELS drops the superseded claude-opus-4-6 identifier (issue #69)', () => {
+  assert.ok(
+    !DEFAULT_MODELS.includes('claude-opus-4-6'),
+    `DEFAULT_MODELS should no longer include 'claude-opus-4-6' after the Opus 4.7 upgrade. Got: ${JSON.stringify(DEFAULT_MODELS)}`,
+  );
+});
+
+test('DEFAULT_MODELS keeps gpt-5.4 as the first entry so the default selection is unchanged', () => {
+  assert.equal(
+    DEFAULT_MODELS[0],
+    'gpt-5.4',
+    `DEFAULT_MODELS[0] must remain 'gpt-5.4' so state.defaultModel is not changed by the Opus 4.7 upgrade. Got: ${JSON.stringify(DEFAULT_MODELS)}`,
+  );
+});
+
+test('DEFAULT_MODELS still exposes claude-sonnet-4-6 (there is no Sonnet 4.7 yet)', () => {
+  assert.ok(
+    DEFAULT_MODELS.includes('claude-sonnet-4-6'),
+    `DEFAULT_MODELS should still include 'claude-sonnet-4-6' because Sonnet 4.7 does not exist. Got: ${JSON.stringify(DEFAULT_MODELS)}`,
+  );
 });

--- a/tests/editor/editor-server.test.js
+++ b/tests/editor/editor-server.test.js
@@ -140,6 +140,139 @@ test('refuses to open a second editor when another slides-grab editor already ow
   }
 });
 
+test('/api/models exposes claude-opus-4-7 so the bbox editor can route edits to Opus 4.7 (issue #69)', async () => {
+  const workspace = await createWorkspace();
+  const port = await getAvailablePort();
+  const server = spawnEditorServer(workspace, port);
+
+  try {
+    await waitForServerReady(port, server.child, server.output);
+
+    const res = await fetch(`http://localhost:${port}/api/models`);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+
+    assert.ok(Array.isArray(body.models), '/api/models must return a models array');
+    assert.ok(
+      body.models.includes('claude-opus-4-7'),
+      `/api/models should include 'claude-opus-4-7' after the Opus 4.7 upgrade. Got: ${JSON.stringify(body.models)}`,
+    );
+    assert.ok(
+      !body.models.includes('claude-opus-4-6'),
+      `/api/models should no longer include 'claude-opus-4-6'. Got: ${JSON.stringify(body.models)}`,
+    );
+    assert.ok(
+      body.models.includes('claude-sonnet-4-6'),
+      `/api/models should still include 'claude-sonnet-4-6' (no Sonnet 4.7 exists). Got: ${JSON.stringify(body.models)}`,
+    );
+    assert.equal(
+      body.defaultModel,
+      'gpt-5.4',
+      '/api/models should keep gpt-5.4 as the default model so the UI selection is unchanged',
+    );
+  } finally {
+    await stopChild(server.child);
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test('/api/apply routes claude-opus-4-7 through the claude CLI with --model claude-opus-4-7 (issue #69)', async () => {
+  const workspace = await createWorkspace();
+  const mockClaude = await writeMockCli(workspace, 'mock-claude.js');
+  const port = await getAvailablePort();
+  const server = spawnEditorServer(workspace, port, {
+    env: {
+      PPT_AGENT_CLAUDE_BIN: mockClaude,
+    },
+  });
+
+  try {
+    await waitForServerReady(port, server.child, server.output);
+
+    const applyRes = await fetch(`http://localhost:${port}/api/apply`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        slide: 'slide-01.html',
+        prompt: 'Upgrade the title styling.',
+        model: 'claude-opus-4-7',
+        selections: [
+          {
+            x: 40,
+            y: 60,
+            width: 320,
+            height: 180,
+            targets: [
+              {
+                xpath: '/html/body/div[1]/h1[1]',
+                tag: 'h1',
+                text: 'Test',
+              },
+            ],
+          },
+        ],
+      }),
+    });
+
+    const applyBody = await applyRes.json();
+    assert.equal(applyRes.status, 200, JSON.stringify(applyBody));
+    assert.equal(applyBody.success, true, `claude-opus-4-7 edit should succeed: ${JSON.stringify(applyBody)}`);
+
+    const logRes = await fetch(`http://localhost:${port}/api/runs/${applyBody.runId}/log`);
+    assert.equal(logRes.status, 200);
+    const log = await logRes.text();
+
+    assert.match(log, /Upgrade the title styling\./);
+  } finally {
+    await stopChild(server.child);
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test('/api/apply rejects the superseded claude-opus-4-6 identifier (issue #69)', async () => {
+  const workspace = await createWorkspace();
+  const port = await getAvailablePort();
+  const server = spawnEditorServer(workspace, port);
+
+  try {
+    await waitForServerReady(port, server.child, server.output);
+
+    const applyRes = await fetch(`http://localhost:${port}/api/apply`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        slide: 'slide-01.html',
+        prompt: 'Try a dropped model.',
+        model: 'claude-opus-4-6',
+        selections: [
+          {
+            x: 40,
+            y: 60,
+            width: 320,
+            height: 180,
+            targets: [],
+          },
+        ],
+      }),
+    });
+
+    assert.equal(applyRes.status, 400, 'claude-opus-4-6 should be rejected with 400 now that it is removed');
+    const body = await applyRes.json();
+    assert.match(body.error || '', /Invalid `model`/);
+    assert.ok(
+      !(body.error || '').includes('claude-opus-4-6'),
+      `error.Allowed models list should no longer mention 'claude-opus-4-6'. Got: ${body.error}`,
+    );
+    assert.ok(
+      (body.error || '').includes('claude-opus-4-7'),
+      `error.Allowed models list should mention 'claude-opus-4-7'. Got: ${body.error}`,
+    );
+  } finally {
+    await stopChild(server.child);
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
 test('card-news editor mode passes square sizing guidance into Codex apply runs', async () => {
   const workspace = await createWorkspace({
     slideHtml: `<!doctype html>


### PR DESCRIPTION
## Summary

Upgrade the editor's bbox Claude model from `claude-opus-4-6` to `claude-opus-4-7` so users picking the Claude engine from the editor's Model dropdown route their edits to Opus 4.7 instead of the superseded 4.6.

Closes #69.

## Changes

| File | Change |
|------|--------|
| `src/editor/codex-edit.js` | `CLAUDE_MODELS`: `claude-opus-4-6` → `claude-opus-4-7` (kept `claude-sonnet-4-6`) |
| `src/editor/js/editor-state.js` | `DEFAULT_MODELS` (client fallback): same replacement; `gpt-5.4` stays at index 0 so the default selection is unchanged |
| `tests/editor/editor-codex-edit.test.js` | New unit tests for `CLAUDE_MODELS`, `isClaudeModel`, `buildClaudeExecArgs`, and `DEFAULT_MODELS` under Opus 4.7 |
| `tests/editor/editor-server.test.js` | New integration tests: `/api/models` lists `claude-opus-4-7`, `/api/apply` accepts `claude-opus-4-7`, `/api/apply` rejects dropped `claude-opus-4-6` |

`buildClaudeExecArgs` is model-agnostic, so `--model claude-opus-4-7` flows through to the `claude` CLI shell-out unchanged. Sonnet stays on `claude-sonnet-4-6` because Sonnet 4.7 does not exist yet. The existing `editor-concurrency.e2e.test.js` claude-sonnet-4-6 timeout test is intentionally left untouched (that model is still valid and still exercises the subprocess timeout path).

## Verification

### TDD

1. **Red** — added 8 new assertions in `editor-codex-edit.test.js` plus 3 new tests in `editor-server.test.js`. Ran `node --test tests/editor/editor-codex-edit.test.js` against the pre-change source. 6 unit assertions failed as expected (missing `claude-opus-4-7`, lingering `claude-opus-4-6`, `isClaudeModel` mismatches).
2. **Green** — flipped the two model-list source-of-truth arrays. All 22 codex-edit tests pass. All 5 editor-server tests pass.
3. **Regression** — `npm test` runs all 149 tests green. `node --test tests/editor/editor-concurrency.e2e.test.js` keeps all 3 concurrency tests green, including the claude-sonnet-4-6 timeout path.

### Manual QA (end-to-end)

Started the editor server against a temp slides dir with a mock `claude` binary (`PPT_AGENT_CLAUDE_BIN=mock-claude.js`) and confirmed:

- `GET /api/models` now returns `"claude-opus-4-7"` and no longer returns `"claude-opus-4-6"`; `defaultModel` stays `gpt-5.4`.
- `POST /api/apply` with `"model":"claude-opus-4-7"` routes to the mock claude CLI with argv `["-p","--dangerously-skip-permissions","--model","claude-opus-4-7","--max-turns","30","--verbose", <prompt>]`.
- `POST /api/apply` with the dropped `"model":"claude-opus-4-6"` returns HTTP 400 with `Invalid \`model\`. Allowed models: gpt-5.4, gpt-5.3-codex, gpt-5.3-codex-spark, claude-opus-4-7, claude-sonnet-4-6`.

<!-- dani:stage=implementation;job=a51e285c2bb24789a5420a6c09515a6b;issue=69 -->
