### PR TITLE
Feature/#73

### DIFF
--- a/scripts/editor-server.js
+++ b/scripts/editor-server.js
@@ -50,7 +50,7 @@ async function loadDeps() {
 
 const DEFAULT_PORT = 3456;
 const DEFAULT_SLIDES_DIR = 'slides';
-const CODEX_MODELS = ['gpt-5.4', 'gpt-5.3-codex', 'gpt-5.3-codex-spark'];
+const CODEX_MODELS = ['gpt-5.5', 'gpt-5.3-codex', 'gpt-5.3-codex-spark'];
 const ALL_MODELS = [...CODEX_MODELS, ...CLAUDE_MODELS];
 const DEFAULT_CODEX_MODEL = CODEX_MODELS[0];
 const SLIDE_FILE_PATTERN = /^slide-.*\.html$/i;

--- a/src/editor/editor.html
+++ b/src/editor/editor.html
@@ -1630,7 +1630,7 @@
             <div class="sidebar-section">
               <span class="sidebar-label">Model</span>
               <select id="model-select" class="model-select">
-                <option value="gpt-5.4">gpt-5.4</option>
+                <option value="gpt-5.5">gpt-5.5</option>
                 <option value="gpt-5.3-codex">gpt-5.3-codex</option>
                 <option value="gpt-5.3-codex-spark">gpt-5.3-codex-spark</option>
               </select>

--- a/src/editor/js/editor-state.js
+++ b/src/editor/js/editor-state.js
@@ -15,7 +15,7 @@ export const POPOVER_TEXT = 'text';
 export const POPOVER_TEXT_COLOR = 'text-color';
 export const POPOVER_BG_COLOR = 'bg-color';
 export const POPOVER_SIZE = 'size';
-export const DEFAULT_MODELS = ['gpt-5.4', 'gpt-5.3-codex', 'gpt-5.3-codex-spark', 'claude-opus-4-7', 'claude-sonnet-4-6'];
+export const DEFAULT_MODELS = ['gpt-5.5', 'gpt-5.3-codex', 'gpt-5.3-codex-spark', 'claude-opus-4-7', 'claude-sonnet-4-6'];
 export const DIRECT_TEXT_TAGS = new Set(['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li']);
 export const NON_SELECTABLE_TAGS = new Set(['html', 'head', 'body', 'script', 'style', 'link', 'meta', 'noscript']);
 

--- a/tests/editor/editor-codex-edit.test.js
+++ b/tests/editor/editor-codex-edit.test.js
@@ -310,11 +310,18 @@ test('DEFAULT_MODELS drops the superseded claude-opus-4-6 identifier (issue #69)
   );
 });
 
-test('DEFAULT_MODELS keeps gpt-5.4 as the first entry so the default selection is unchanged', () => {
+test('DEFAULT_MODELS uses gpt-5.5 as the first entry per issue #73 (gpt-5.4 deprecation)', () => {
   assert.equal(
     DEFAULT_MODELS[0],
-    'gpt-5.4',
-    `DEFAULT_MODELS[0] must remain 'gpt-5.4' so state.defaultModel is not changed by the Opus 4.7 upgrade. Got: ${JSON.stringify(DEFAULT_MODELS)}`,
+    'gpt-5.5',
+    `DEFAULT_MODELS[0] must be 'gpt-5.5' per issue #73 after gpt-5.4 deprecation, so state.defaultModel opens fresh sessions on the supported model. Got: ${JSON.stringify(DEFAULT_MODELS)}`,
+  );
+});
+
+test('DEFAULT_MODELS drops the deprecated gpt-5.4 identifier (issue #73)', () => {
+  assert.ok(
+    !DEFAULT_MODELS.includes('gpt-5.4'),
+    `DEFAULT_MODELS should no longer include the deprecated 'gpt-5.4' per issue #73. Got: ${JSON.stringify(DEFAULT_MODELS)}`,
   );
 });
 

--- a/tests/editor/editor-server.test.js
+++ b/tests/editor/editor-server.test.js
@@ -167,8 +167,16 @@ test('/api/models exposes claude-opus-4-7 so the bbox editor can route edits to 
     );
     assert.equal(
       body.defaultModel,
-      'gpt-5.4',
-      '/api/models should keep gpt-5.4 as the default model so the UI selection is unchanged',
+      'gpt-5.5',
+      '/api/models should advertise gpt-5.5 as the default model per issue #73 after gpt-5.4 deprecation',
+    );
+    assert.ok(
+      body.models.includes('gpt-5.5'),
+      `/api/models should include 'gpt-5.5' per issue #73. Got: ${JSON.stringify(body.models)}`,
+    );
+    assert.ok(
+      !body.models.includes('gpt-5.4'),
+      `/api/models should no longer include the deprecated 'gpt-5.4' per issue #73. Got: ${JSON.stringify(body.models)}`,
     );
   } finally {
     await stopChild(server.child);

--- a/tests/editor/editor-ui.e2e.test.js
+++ b/tests/editor/editor-ui.e2e.test.js
@@ -234,7 +234,7 @@ test('keeps bbox prompt draft and model state per slide session', { concurrency:
     await page.waitForTimeout(800);
 
     // slide-01
-    await page.selectOption('#model-select', 'gpt-5.4');
+    await page.selectOption('#model-select', 'gpt-5.5');
     await page.fill('#prompt-input', 'slide-01 prompt');
 
     // slide-02
@@ -254,7 +254,7 @@ test('keeps bbox prompt draft and model state per slide session', { concurrency:
     });
 
     const restoredModel = await page.$eval('#model-select', (el) => el.value);
-    assert.equal(restoredModel, 'gpt-5.4');
+    assert.equal(restoredModel, 'gpt-5.5');
     const restoredPrompt = await page.$eval('#prompt-input', (el) => el.value);
     assert.equal(restoredPrompt, 'slide-01 prompt');
 


### PR DESCRIPTION
## Summary

Closes #73.

`gpt-5.4` is deprecated. Swap it for `gpt-5.5` as the first entry in the editor's
model dropdown so new bbox → prompt → Codex sessions open on a supported model and
the feedback loop keeps routing to a live Codex target.

## Changes

**Production (3 files, one-line swaps each):**

- `src/editor/js/editor-state.js` — `DEFAULT_MODELS[0]` → `'gpt-5.5'`; `state.defaultModel`
  and `state.selectedModel` re-derive automatically.
- `scripts/editor-server.js` — `CODEX_MODELS[0]` → `'gpt-5.5'`, which flows into
  `DEFAULT_CODEX_MODEL = CODEX_MODELS[0]` and the `/api/models` response.
- `src/editor/editor.html` — first `<option>` inside `#model-select` is now `gpt-5.5`,
  preserving "first-slot = default" semantics for the dropdown.

**Tests (3 files, TDD-driven):**

- `tests/editor/editor-codex-edit.test.js` — updated the default-lock test to assert
  `DEFAULT_MODELS[0] === 'gpt-5.5'` per issue #73, plus a new parallel "drops the
  deprecated gpt-5.4 identifier" guard that mirrors the issue #69 Opus 4.7 pattern.
- `tests/editor/editor-server.test.js` — `/api/models` now must advertise
  `defaultModel: "gpt-5.5"`, must include `'gpt-5.5'`, and must not include `'gpt-5.4'`.
- `tests/editor/editor-ui.e2e.test.js` — the Playwright per-slide persistence test
  now selects and round-trips `'gpt-5.5'` through the editor UI.

**Intentionally NOT changed:**

- `skills/slides-grab-design/references/beautiful-slide-defaults.md` keeps its
  attribution line (`"adapted from OpenAI's frontend design guidance for GPT-5.4"`)
  because that is a historical source citation, not a runtime model identifier.
- `gpt-5.3-codex` / `gpt-5.3-codex-spark` are unrelated and stay as additional options.
- No data migration — persisted per-slide state that still carries `'gpt-5.4'` is
  already handled gracefully by the existing fallbacks in `editor-navigation.js`,
  `editor-utils.js`, and `editor-send.js`.

## Verification

**TDD:**

1. Updated test assertions first and ran `node --test tests/editor/editor-codex-edit.test.js`
   → observed the 2 new/updated tests fail with
   `expected 'gpt-5.5', actual 'gpt-5.4'` (RED).
2. Applied the 3 production swaps and re-ran → all 23 tests in that file pass (GREEN).

**Full suite:**

- `npm test` → **150 / 150 tests pass** (0 failures).
- `node --test tests/editor/editor-ui.e2e.test.js` → **5 / 5 Playwright e2e tests pass**,
  including the updated persistence test that round-trips `gpt-5.5` through the UI.

**Manual QA (feedback loop round-trip):**

Started `scripts/editor-server.js` against a scratch slides directory:

```
GET /api/models
{
  "models": ["gpt-5.5", "gpt-5.3-codex", "gpt-5.3-codex-spark",
             "claude-opus-4-7", "claude-sonnet-4-6"],
  "defaultModel": "gpt-5.5"
}
```

Rendered `#model-select` block:

```html
<select id="model-select" class="model-select">
  <option value="gpt-5.5">gpt-5.5</option>
  <option value="gpt-5.3-codex">gpt-5.3-codex</option>
  <option value="gpt-5.3-codex-spark">gpt-5.3-codex-spark</option>
</select>
```

Confirmed: the editor opens on `gpt-5.5` by default and the server will forward
`--model gpt-5.5` to `codex exec` when a user clicks **Run Codex** — the feedback
loop now targets the supported model end-to-end.

<!-- dani:stage=implementation;job=c127351f70ac4726a71a37637bd0b36a;issue=73 -->
