### PR TITLE
fix(editor): add opus 4.8 Claude support

### DIFF
--- a/src/editor/codex-edit.js
+++ b/src/editor/codex-edit.js
@@ -486,10 +486,35 @@ export function buildCodexExecArgs({ prompt, imagePath, model }) {
 
 export { CLAUDE_MODELS, isClaudeModel } from './js/model-registry.js';
 
+const CLAUDE_PERMISSION_MODES = new Set([
+  'acceptEdits',
+  'auto',
+  'bypassPermissions',
+  'default',
+  'dontAsk',
+  'plan',
+]);
+
+function buildClaudePermissionArgs() {
+  if (process.env.PPT_AGENT_CLAUDE_SKIP_PERMISSIONS === '1') {
+    return ['--dangerously-skip-permissions'];
+  }
+
+  const permissionMode = process.env.PPT_AGENT_CLAUDE_PERMISSION_MODE?.trim() || 'acceptEdits';
+  if (!CLAUDE_PERMISSION_MODES.has(permissionMode)) {
+    throw new Error(
+      `Invalid PPT_AGENT_CLAUDE_PERMISSION_MODE: ${permissionMode}. ` +
+      `Allowed values: ${Array.from(CLAUDE_PERMISSION_MODES).join(', ')}`,
+    );
+  }
+
+  return ['--permission-mode', permissionMode];
+}
+
 export function buildClaudeExecArgs({ prompt, imagePath, model }) {
   const args = [
     '-p',
-    '--dangerously-skip-permissions',
+    ...buildClaudePermissionArgs(),
     '--model', model.trim(),
     '--max-turns', '30',
     '--verbose',

--- a/src/editor/editor.html
+++ b/src/editor/editor.html
@@ -1634,7 +1634,7 @@
                 <option value="gpt-5.4">gpt-5.4</option>
                 <option value="gpt-5.3-codex">gpt-5.3-codex</option>
                 <option value="gpt-5.3-codex-spark">gpt-5.3-codex-spark</option>
-                <option value="claude-opus-4-7">claude-opus-4-7</option>
+                <option value="claude-opus-4-8">claude-opus-4-8</option>
                 <option value="claude-sonnet-4-6">claude-sonnet-4-6</option>
               </select>
             </div>

--- a/src/editor/js/model-registry.js
+++ b/src/editor/js/model-registry.js
@@ -18,7 +18,7 @@ export const CODEX_MODELS = [
   'gpt-5.3-codex-spark',
 ];
 
-export const CLAUDE_MODELS = ['claude-opus-4-7', 'claude-sonnet-4-6'];
+export const CLAUDE_MODELS = ['claude-opus-4-8', 'claude-sonnet-4-6'];
 
 export const ALL_MODELS = [...CODEX_MODELS, ...CLAUDE_MODELS];
 

--- a/tests/editor/editor-codex-edit.test.js
+++ b/tests/editor/editor-codex-edit.test.js
@@ -31,6 +31,39 @@ async function importFreshCodexEditModule() {
   return import(moduleUrl.href);
 }
 
+function withClaudePermissionEnv(env, callback) {
+  const originalPermissionMode = process.env.PPT_AGENT_CLAUDE_PERMISSION_MODE;
+  const originalSkip = process.env.PPT_AGENT_CLAUDE_SKIP_PERMISSIONS;
+
+  try {
+    if (env.permissionMode === undefined) {
+      delete process.env.PPT_AGENT_CLAUDE_PERMISSION_MODE;
+    } else {
+      process.env.PPT_AGENT_CLAUDE_PERMISSION_MODE = env.permissionMode;
+    }
+
+    if (env.skipPermissions === undefined) {
+      delete process.env.PPT_AGENT_CLAUDE_SKIP_PERMISSIONS;
+    } else {
+      process.env.PPT_AGENT_CLAUDE_SKIP_PERMISSIONS = env.skipPermissions;
+    }
+
+    return callback();
+  } finally {
+    if (originalPermissionMode === undefined) {
+      delete process.env.PPT_AGENT_CLAUDE_PERMISSION_MODE;
+    } else {
+      process.env.PPT_AGENT_CLAUDE_PERMISSION_MODE = originalPermissionMode;
+    }
+
+    if (originalSkip === undefined) {
+      delete process.env.PPT_AGENT_CLAUDE_SKIP_PERMISSIONS;
+    } else {
+      process.env.PPT_AGENT_CLAUDE_SKIP_PERMISSIONS = originalSkip;
+    }
+  }
+}
+
 test('normalizeSelection rounds values and clamps to slide bounds', () => {
   const selection = normalizeSelection(
     {
@@ -252,17 +285,17 @@ test('buildCodexEditPrompt switches sizing guidance for card-news mode', () => {
   assert.match(prompt, /Keep slide dimensions at 720pt x 720pt\./);
 });
 
-test('CLAUDE_MODELS exposes claude-opus-4-7 as the bbox-editor Opus option (issue #69)', () => {
+test('CLAUDE_MODELS exposes claude-opus-4-8 as the bbox-editor Opus option (issue #88)', () => {
   assert.ok(
-    CLAUDE_MODELS.includes('claude-opus-4-7'),
-    `CLAUDE_MODELS should include 'claude-opus-4-7' so the editor dropdown can route edits to Opus 4.7. Got: ${JSON.stringify(CLAUDE_MODELS)}`,
+    CLAUDE_MODELS.includes('claude-opus-4-8'),
+    `CLAUDE_MODELS should include 'claude-opus-4-8' so the editor dropdown can route edits to Opus 4.8. Got: ${JSON.stringify(CLAUDE_MODELS)}`,
   );
 });
 
-test('CLAUDE_MODELS drops the superseded claude-opus-4-6 identifier (issue #69)', () => {
+test('CLAUDE_MODELS drops the superseded claude-opus-4-7 identifier (issue #88)', () => {
   assert.ok(
-    !CLAUDE_MODELS.includes('claude-opus-4-6'),
-    `CLAUDE_MODELS should no longer include 'claude-opus-4-6' after the Opus 4.7 upgrade. Got: ${JSON.stringify(CLAUDE_MODELS)}`,
+    !CLAUDE_MODELS.includes('claude-opus-4-7'),
+    `CLAUDE_MODELS should no longer include 'claude-opus-4-7' after the Opus 4.8 upgrade. Got: ${JSON.stringify(CLAUDE_MODELS)}`,
   );
 });
 
@@ -273,27 +306,28 @@ test('CLAUDE_MODELS still exposes claude-sonnet-4-6 (there is no Sonnet 4.7 yet)
   );
 });
 
-test('isClaudeModel recognizes claude-opus-4-7 after the upgrade', () => {
-  assert.equal(isClaudeModel('claude-opus-4-7'), true);
-  assert.equal(isClaudeModel('  claude-opus-4-7  '), true);
+test('isClaudeModel recognizes claude-opus-4-8 after the upgrade', () => {
+  assert.equal(isClaudeModel('claude-opus-4-8'), true);
+  assert.equal(isClaudeModel('  claude-opus-4-8  '), true);
 });
 
-test('isClaudeModel rejects the dropped claude-opus-4-6 identifier', () => {
-  assert.equal(isClaudeModel('claude-opus-4-6'), false);
+test('isClaudeModel rejects the dropped claude-opus-4-7 identifier', () => {
+  assert.equal(isClaudeModel('claude-opus-4-7'), false);
 });
 
-test('buildClaudeExecArgs forwards claude-opus-4-7 to the claude CLI --model flag', () => {
-  const args = buildClaudeExecArgs({
+test('buildClaudeExecArgs forwards claude-opus-4-8 to the claude CLI --model flag', () => {
+  const args = withClaudePermissionEnv({}, () => buildClaudeExecArgs({
     prompt: 'Edit slide',
     imagePath: '/tmp/slide-annotated.png',
-    model: 'claude-opus-4-7',
-  });
+    model: 'claude-opus-4-8',
+  }));
 
   assert.deepEqual(args, [
     '-p',
-    '--dangerously-skip-permissions',
+    '--permission-mode',
+    'acceptEdits',
     '--model',
-    'claude-opus-4-7',
+    'claude-opus-4-8',
     '--max-turns',
     '30',
     '--verbose',
@@ -301,18 +335,64 @@ test('buildClaudeExecArgs forwards claude-opus-4-7 to the claude CLI --model fla
   ]);
 });
 
-test('DEFAULT_MODELS exposes claude-opus-4-7 as the Claude Opus fallback (issue #69)', () => {
+test('buildClaudeExecArgs keeps dangerous skip permissions as an explicit opt-in for legacy sandboxes', () => {
+  const args = withClaudePermissionEnv({ skipPermissions: '1' }, () => buildClaudeExecArgs({
+    prompt: 'Edit slide',
+    imagePath: '',
+    model: 'claude-opus-4-8',
+  }));
+
+  assert.deepEqual(args, [
+    '-p',
+    '--dangerously-skip-permissions',
+    '--model',
+    'claude-opus-4-8',
+    '--max-turns',
+    '30',
+    '--verbose',
+    'Edit slide',
+  ]);
+});
+
+test('buildClaudeExecArgs uses configurable Claude permission mode for OAuth-friendly sessions (issue #88)', () => {
+  const args = withClaudePermissionEnv({ permissionMode: 'acceptEdits' }, () => buildClaudeExecArgs({
+    prompt: 'Edit slide',
+    imagePath: '',
+    model: 'claude-opus-4-8',
+  }));
+
+  assert.deepEqual(args, [
+    '-p',
+    '--permission-mode',
+    'acceptEdits',
+    '--model',
+    'claude-opus-4-8',
+    '--max-turns',
+    '30',
+    '--verbose',
+    'Edit slide',
+  ]);
+});
+
+test('DEFAULT_MODELS exposes claude-opus-4-8 as the Claude Opus fallback (issue #88)', () => {
   assert.ok(
-    DEFAULT_MODELS.includes('claude-opus-4-7'),
-    `DEFAULT_MODELS should include 'claude-opus-4-7' so the editor UI dropdown falls back to Opus 4.7 when /api/models is unreachable. Got: ${JSON.stringify(DEFAULT_MODELS)}`,
+    DEFAULT_MODELS.includes('claude-opus-4-8'),
+    `DEFAULT_MODELS should include 'claude-opus-4-8' so the editor UI dropdown falls back to Opus 4.8 when /api/models is unreachable. Got: ${JSON.stringify(DEFAULT_MODELS)}`,
   );
 });
 
-test('DEFAULT_MODELS drops the superseded claude-opus-4-6 identifier (issue #69)', () => {
+test('DEFAULT_MODELS drops the superseded claude-opus-4-7 identifier (issue #88)', () => {
   assert.ok(
-    !DEFAULT_MODELS.includes('claude-opus-4-6'),
-    `DEFAULT_MODELS should no longer include 'claude-opus-4-6' after the Opus 4.7 upgrade. Got: ${JSON.stringify(DEFAULT_MODELS)}`,
+    !DEFAULT_MODELS.includes('claude-opus-4-7'),
+    `DEFAULT_MODELS should no longer include 'claude-opus-4-7' after the Opus 4.8 upgrade. Got: ${JSON.stringify(DEFAULT_MODELS)}`,
   );
+});
+
+test('static editor fallback select exposes claude-opus-4-8 and not superseded claude-opus-4-7 (issue #88)', () => {
+  const html = readFileSync(new URL('../../src/editor/editor.html', import.meta.url), 'utf8');
+
+  assert.match(html, /<option value="claude-opus-4-8">claude-opus-4-8<\/option>/);
+  assert.doesNotMatch(html, /<option value="claude-opus-4-7">claude-opus-4-7<\/option>/);
 });
 
 test('DEFAULT_MODELS uses gpt-5.5 as the first entry per issue #73 (gpt-5.4 deprecation)', () => {

--- a/tests/editor/editor-server.test.js
+++ b/tests/editor/editor-server.test.js
@@ -29,6 +29,7 @@ async function writeMockCli(workspace, fileName) {
   const mockPath = join(workspace, fileName);
   const script = `#!/usr/bin/env node
 const prompt = process.argv[process.argv.length - 1] || '';
+process.stdout.write(process.argv.slice(2).join(' ') + '\\n');
 process.stdout.write(prompt);
 process.exit(0);
 `;
@@ -140,7 +141,7 @@ test('refuses to open a second editor when another slides-grab editor already ow
   }
 });
 
-test('/api/models exposes claude-opus-4-7 so the bbox editor can route edits to Opus 4.7 (issue #69)', async () => {
+test('/api/models exposes claude-opus-4-8 so the bbox editor can route edits to Opus 4.8 (issue #88)', async () => {
   const workspace = await createWorkspace();
   const port = await getAvailablePort();
   const server = spawnEditorServer(workspace, port);
@@ -154,12 +155,12 @@ test('/api/models exposes claude-opus-4-7 so the bbox editor can route edits to 
 
     assert.ok(Array.isArray(body.models), '/api/models must return a models array');
     assert.ok(
-      body.models.includes('claude-opus-4-7'),
-      `/api/models should include 'claude-opus-4-7' after the Opus 4.7 upgrade. Got: ${JSON.stringify(body.models)}`,
+      body.models.includes('claude-opus-4-8'),
+      `/api/models should include 'claude-opus-4-8' after the Opus 4.8 upgrade. Got: ${JSON.stringify(body.models)}`,
     );
     assert.ok(
-      !body.models.includes('claude-opus-4-6'),
-      `/api/models should no longer include 'claude-opus-4-6'. Got: ${JSON.stringify(body.models)}`,
+      !body.models.includes('claude-opus-4-7'),
+      `/api/models should no longer include 'claude-opus-4-7'. Got: ${JSON.stringify(body.models)}`,
     );
     assert.ok(
       body.models.includes('claude-sonnet-4-6'),
@@ -247,7 +248,7 @@ test('/api/apply injects DESIGN.slides.md from the active --slides-dir, not laun
   }
 });
 
-test('/api/apply routes claude-opus-4-7 through the claude CLI with --model claude-opus-4-7 (issue #69)', async () => {
+test('/api/apply routes claude-opus-4-8 through the claude CLI with --model claude-opus-4-8 (issue #88)', async () => {
   const workspace = await createWorkspace();
   const mockClaude = await writeMockCli(workspace, 'mock-claude.js');
   const port = await getAvailablePort();
@@ -266,7 +267,7 @@ test('/api/apply routes claude-opus-4-7 through the claude CLI with --model clau
       body: JSON.stringify({
         slide: 'slide-01.html',
         prompt: 'Upgrade the title styling.',
-        model: 'claude-opus-4-7',
+        model: 'claude-opus-4-8',
         selections: [
           {
             x: 40,
@@ -287,20 +288,21 @@ test('/api/apply routes claude-opus-4-7 through the claude CLI with --model clau
 
     const applyBody = await applyRes.json();
     assert.equal(applyRes.status, 200, JSON.stringify(applyBody));
-    assert.equal(applyBody.success, true, `claude-opus-4-7 edit should succeed: ${JSON.stringify(applyBody)}`);
+    assert.equal(applyBody.success, true, `claude-opus-4-8 edit should succeed: ${JSON.stringify(applyBody)}`);
 
     const logRes = await fetch(`http://localhost:${port}/api/runs/${applyBody.runId}/log`);
     assert.equal(logRes.status, 200);
     const log = await logRes.text();
 
     assert.match(log, /Upgrade the title styling\./);
+    assert.match(log, /--model claude-opus-4-8/);
   } finally {
     await stopChild(server.child);
     await rm(workspace, { recursive: true, force: true });
   }
 });
 
-test('/api/apply rejects the superseded claude-opus-4-6 identifier (issue #69)', async () => {
+test('/api/apply rejects the superseded claude-opus-4-7 identifier (issue #88)', async () => {
   const workspace = await createWorkspace();
   const port = await getAvailablePort();
   const server = spawnEditorServer(workspace, port);
@@ -314,7 +316,7 @@ test('/api/apply rejects the superseded claude-opus-4-6 identifier (issue #69)',
       body: JSON.stringify({
         slide: 'slide-01.html',
         prompt: 'Try a dropped model.',
-        model: 'claude-opus-4-6',
+        model: 'claude-opus-4-7',
         selections: [
           {
             x: 40,
@@ -327,16 +329,16 @@ test('/api/apply rejects the superseded claude-opus-4-6 identifier (issue #69)',
       }),
     });
 
-    assert.equal(applyRes.status, 400, 'claude-opus-4-6 should be rejected with 400 now that it is removed');
+    assert.equal(applyRes.status, 400, 'claude-opus-4-7 should be rejected with 400 now that it is removed');
     const body = await applyRes.json();
     assert.match(body.error || '', /Invalid `model`/);
     assert.ok(
-      !(body.error || '').includes('claude-opus-4-6'),
-      `error.Allowed models list should no longer mention 'claude-opus-4-6'. Got: ${body.error}`,
+      !(body.error || '').includes('claude-opus-4-7'),
+      `error.Allowed models list should no longer mention 'claude-opus-4-7'. Got: ${body.error}`,
     );
     assert.ok(
-      (body.error || '').includes('claude-opus-4-7'),
-      `error.Allowed models list should mention 'claude-opus-4-7'. Got: ${body.error}`,
+      (body.error || '').includes('claude-opus-4-8'),
+      `error.Allowed models list should mention 'claude-opus-4-8'. Got: ${body.error}`,
     );
   } finally {
     await stopChild(server.child);


### PR DESCRIPTION
## Summary
- Replace the slide editor Claude Opus entry with `claude-opus-4-8` in the canonical model registry and static editor fallback dropdown.
- Route `claude-opus-4-8` through the Claude CLI path and reject superseded `claude-opus-4-7` during `/api/apply` validation.
- Default Claude Code edits to documented `--permission-mode acceptEdits` for OAuth-friendly sessions, while keeping `--dangerously-skip-permissions` behind explicit `PPT_AGENT_CLAUDE_SKIP_PERMISSIONS=1` for legacy sandbox use.

## TDD Evidence
- RED: `.omo/ulw-loop/evidence/red-targeted-tests.txt` captured expected failures for `claude-opus-4-8` registry/API/routing/fallback and permission-mode assertions before production changes.
- GREEN: `.omo/ulw-loop/evidence/green-targeted-tests-after-env-isolation.txt` shows targeted editor tests passing 45/45 after implementation.

## Manual QA
- C001 `/api/models`: `.omo/ulw-loop/evidence/C001-api-models.txt` captured `curl -i` HTTP 200 with `claude-opus-4-8`, no `claude-opus-4-7`, and default `gpt-5.5`.
- C002 `/api/apply`: `.omo/ulw-loop/evidence/C002-api-apply-routing.txt` captured HTTP success for `claude-opus-4-8` with `--model claude-opus-4-8` in the run log, and HTTP 400 for `claude-opus-4-7`.
- C003 fallback/permissions: `.omo/ulw-loop/evidence/C003-fallback-permission.txt` captured a tmux run proving fallback state and `--permission-mode acceptEdits` argv.

## Verification
- `node --test tests/editor/editor-codex-edit.test.js tests/editor/editor-server.test.js tests/editor/editor-model-dispatch.test.js` PASS 45/45.
- `npm test` PASS 239/239 in `.omo/ulw-loop/evidence/npm-test-final.txt`.
- LSP diagnostics clean on changed source/test files.
- Reviewer verdict: APPROVE.

Closes #88
